### PR TITLE
Fix tests for case-insensitive FS

### DIFF
--- a/src/mock.rs
+++ b/src/mock.rs
@@ -32,7 +32,7 @@ pub fn normalize(s: &str) -> String {
 	format!("{}\n", lines.join("\n"))
 }
 
-pub fn git_init(dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+pub fn git_init(dir: &Path) -> Result<(), anyhow::Error> {
 	let mut cmd = Command::new("git");
 	cmd.current_dir(dir);
 	cmd.arg("init");


### PR DESCRIPTION
Changes:
- Deterministically morph temporary crate paths such that they wont collide on case-insensitive file systems.