### PR TITLE
Require to pass on Substrate master

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -44,7 +44,7 @@ jobs:
         echo "Checking features #3"
         zepter lint propagate-feature --feature std --left-side-feature-missing=ignore --workspace
         echo "Checking formatting #1"
-        zepter format features --exit-code-zero
+        zepter format features --check
     - if: matrix.repo != 'substrate'
       name: Zepter doesnt panic
       # Polkadot and Cumulus can be red, but should not panic. Hence the `--exit-code-zero`.


### PR DESCRIPTION
https://github.com/paritytech/substrate/pull/14803 should ensure that Substrate master stays formatted.  
https://github.com/paritytech/substrate/pull/14660 already ensures the feature correctness.  
We can therefore check this here already to ensure to not break downstream repos.