### PR TITLE
Take default-features into account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zepter"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zepter"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = [ "Oliver Tale-Yazdi" ]
 description = "Analyze, Fix and Format features in your Rust workspace."

--- a/src/cmd/lint.rs
+++ b/src/cmd/lint.rs
@@ -363,11 +363,8 @@ impl PropagateFeatureCmd {
 		let mut propagate_missing = BTreeMap::<CrateId, BTreeSet<RenamedPackage>>::new();
 		// (Crate that missing the feature) -> (Dependency that has it)
 		let mut feature_missing = BTreeMap::<CrateId, BTreeSet<RenamedPackage>>::new();
-		// Crate that has the feature but does not need it.
-		let mut feature_maybe_unused = BTreeSet::<CrateId>::new();
 
 		for pkg in to_check.iter() {
-			let mut feature_used = false;
 			// TODO that it does not enable other features.
 
 			for dep in pkg.dependencies.iter() {
@@ -376,7 +373,6 @@ impl PropagateFeatureCmd {
 				let Some(dep) = resolve_dep(pkg, dep, &meta) else {
 					// Either outside workspace or not resolved, possibly due to not being used at
 					// all because of the target or whatever.
-					feature_used = true;
 					continue
 				};
 
@@ -406,7 +402,7 @@ impl PropagateFeatureCmd {
 				});
 				if let Some(p) = sub_dag.any_path(&default_entrypoint, &target) {
 					// Easy case, all good.
-					log::info!("Reachable from the default entrypoint: {:?} vis {:?}", target, p.0);
+					log::debug!("Reachable from the default entrypoint: {:?} vis {:?}", target, p.0);
 					continue
 				}
 				// Now the more complicated case where `pkg/F -> dep/G .. -> dep/F`. So to say a
@@ -660,7 +656,7 @@ fn build_feature_dag(meta: &Metadata, pkgs: &[Package]) -> Dag<CrateAndFeature> 
 					CrateAndFeature(pkg.id.to_string(), "#entrypoint".into()),
 					CrateAndFeature(dep_id.pkg.id.repr.clone(), "default".into()),
 				);
-				log::info!("Adding default entrypoint for {} on {}", dep.name, pkg.name);
+				log::debug!("Adding default entrypoint for {} on {}", dep.name, pkg.name);
 			}
 			for feature in &dep.features {
 				dag.add_edge(

--- a/src/cmd/lint.rs
+++ b/src/cmd/lint.rs
@@ -402,7 +402,11 @@ impl PropagateFeatureCmd {
 				});
 				if let Some(p) = sub_dag.any_path(&default_entrypoint, &target) {
 					// Easy case, all good.
-					log::debug!("Reachable from the default entrypoint: {:?} vis {:?}", target, p.0);
+					log::debug!(
+						"Reachable from the default entrypoint: {:?} vis {:?}",
+						target,
+						p.0
+					);
 					continue
 				}
 				// Now the more complicated case where `pkg/F -> dep/G .. -> dep/F`. So to say a
@@ -646,11 +650,9 @@ fn build_feature_dag(meta: &Metadata, pkgs: &[Package]) -> Dag<CrateAndFeature> 
 					CrateAndFeature(pkg.id.to_string(), "default".into()),
 					CrateAndFeature(dep.name.clone(), "default".into()),
 				);
-				
-				let Some(dep_id) = resolve_dep(pkg, dep, meta) else {
-					continue;
-				};
-				
+
+				let Some(dep_id) = resolve_dep(pkg, dep, meta) else { continue };
+
 				// Hacky…
 				dag.add_edge(
 					CrateAndFeature(pkg.id.to_string(), "#entrypoint".into()),

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -139,11 +139,16 @@ where
 		self.edges.entry(node).or_default();
 	}
 
-	/// Whether `from` is directly connected to `to`.
+	/// Whether `from` is directly adjacent to `to`.
 	///
 	/// *Directly* means with via an edge.
-	pub fn connected(&self, from: &T, to: &T) -> bool {
+	pub fn adjacent(&self, from: &T, to: &T) -> bool {
 		self.edges.get(from).map_or(false, |v| v.contains(to))
+	}
+
+	/// Whether `from` is connected to `to` via.
+	pub fn connected(&self, from: &T, to: &T) -> bool {
+		self.any_path(from, to).is_some()
 	}
 
 	/// Whether `from` appears on the lhs of the edge relation.

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -146,8 +146,8 @@ where
 		self.edges.get(from).map_or(false, |v| v.contains(to))
 	}
 
-	/// Whether `from` is connected to `to` via.
-	pub fn connected(&self, from: &T, to: &T) -> bool {
+	/// Whether `from` is reachable to `to` via.
+	pub fn reachable(&self, from: &T, to: &T) -> bool {
 		self.any_path(from, to).is_some()
 	}
 
@@ -173,6 +173,16 @@ where
 		let mut edges = BTreeMap::new();
 		let rhs = self.edges.get(&from).cloned().unwrap_or_default();
 		edges.insert(from, rhs);
+		Self { edges }
+	}
+
+	pub fn sub(&self, pred: impl Fn(&T) -> bool) -> Self {
+		let mut edges = BTreeMap::new();
+		for (k, v) in self.edges.iter() {
+			if pred(k) {
+				edges.insert(k.clone(), v.clone());
+			}
+		}
 		Self { edges }
 	}
 

--- a/tests/integration/polkadot/issue-7261.yaml
+++ b/tests/integration/polkadot/issue-7261.yaml
@@ -8,9 +8,7 @@ cases:
       feature 'std'
         must propagate to:
           polkadot-runtime-parachains
-          serde_json
           beefy-primitives (renamed from sp-consensus-beefy)
           sp-mmr-primitives
-          sp-trie
-    Found 5 issues and fixed 5.
-  diff: "diff --git runtime/test-runtime/Cargo.toml runtime/test-runtime/Cargo.toml\nindex 6d38a0..8f3418 100644\n--- runtime/test-runtime/Cargo.toml\n+++ runtime/test-runtime/Cargo.toml\n@@ -130,0 +131,5 @@ std = [\n+\t\"polkadot-runtime-parachains/std\",\n+\t\"serde_json/std\",\n+\t\"beefy-primitives/std\",\n+\t\"sp-mmr-primitives/std\",\n+\t\"sp-trie/std\"\n"
+    Found 3 issues and fixed 3.
+  diff: "diff --git runtime/test-runtime/Cargo.toml runtime/test-runtime/Cargo.toml\nindex 6d38a0..972533 100644\n--- runtime/test-runtime/Cargo.toml\n+++ runtime/test-runtime/Cargo.toml\n@@ -130,0 +131,3 @@ std = [\n+\t\"polkadot-runtime-parachains/std\",\n+\t\"beefy-primitives/std\",\n+\t\"sp-mmr-primitives/std\"\n"

--- a/tests/integration/sdk/propagate.yaml
+++ b/tests/integration/sdk/propagate.yaml
@@ -7,7 +7,6 @@ cases:
     crate 'asset-hub-kusama-runtime'
       feature 'std'
         must propagate to:
-          asset-test-utils
           cumulus-pallet-session-benchmarking
           frame-benchmarking
           frame-system-benchmarking
@@ -18,7 +17,6 @@ cases:
     crate 'asset-hub-polkadot-runtime'
       feature 'std'
         must propagate to:
-          asset-test-utils
           cumulus-pallet-session-benchmarking
           frame-benchmarking
           frame-system-benchmarking
@@ -29,22 +27,16 @@ cases:
     crate 'asset-hub-westend-runtime'
       feature 'std'
         must propagate to:
-          asset-test-utils
           cumulus-pallet-session-benchmarking
           frame-benchmarking
           frame-system-benchmarking
           frame-try-runtime
           pallet-xcm-benchmarks
-          sp-io
           sp-storage
     crate 'asset-test-utils'
       feature 'std'
         must propagate to:
           sp-core
-    crate 'bp-header-chain'
-      feature 'std'
-        must propagate to:
-          bp-test-utils
     crate 'bp-test-utils'
       feature 'std'
         must propagate to:
@@ -54,7 +46,6 @@ cases:
     crate 'bridge-hub-kusama-runtime'
       feature 'std'
         must propagate to:
-          bridge-hub-test-utils
           cumulus-pallet-session-benchmarking
           frame-benchmarking
           frame-system-benchmarking
@@ -64,7 +55,6 @@ cases:
     crate 'bridge-hub-polkadot-runtime'
       feature 'std'
         must propagate to:
-          bridge-hub-test-utils
           cumulus-pallet-session-benchmarking
           frame-benchmarking
           frame-system-benchmarking
@@ -74,7 +64,6 @@ cases:
     crate 'bridge-hub-rococo-runtime'
       feature 'std'
         must propagate to:
-          bridge-hub-test-utils
           cumulus-pallet-session-benchmarking
           frame-system-benchmarking
           frame-try-runtime
@@ -89,8 +78,6 @@ cases:
       feature 'std'
         must propagate to:
           bp-relayers
-          bp-test-utils
-          pallet-balances
     crate 'collectives-polkadot-runtime'
       feature 'std'
         must propagate to:
@@ -120,11 +107,8 @@ cases:
     crate 'cumulus-pallet-parachain-system'
       feature 'std'
         must propagate to:
-          cumulus-test-relay-sproof-builder
           polkadot-parachain
           sp-inherents
-          sp-tracing
-          sp-version
     crate 'cumulus-pallet-xcm'
       feature 'std'
         must propagate to:
@@ -132,11 +116,7 @@ cases:
     crate 'cumulus-pallet-xcmp-queue'
       feature 'std'
         must propagate to:
-          cumulus-pallet-parachain-system
           frame-benchmarking
-          pallet-balances
-          sp-core
-          xcm-builder
     crate 'cumulus-ping'
       feature 'std'
         must propagate to:
@@ -145,14 +125,6 @@ cases:
       feature 'std'
         must propagate to:
           xcm
-    crate 'cumulus-primitives-parachain-inherent'
-      feature 'std'
-        must propagate to:
-          cumulus-test-relay-sproof-builder
-          sp-api
-          sp-runtime
-          sp-state-machine
-          sp-storage
     crate 'cumulus-test-relay-sproof-builder'
       feature 'std'
         must propagate to:
@@ -177,69 +149,16 @@ cases:
           pallet-xcm-benchmarks
           sp-storage
           sp-tracing
-          sp-trie
-    crate 'pallet-bridge-grandpa'
-      feature 'std'
-        must propagate to:
-          sp-core
-          sp-io
-    crate 'pallet-bridge-messages'
-      feature 'std'
-        must propagate to:
-          bp-test-utils
-          pallet-balances
-          sp-io
-    crate 'pallet-bridge-parachains'
-      feature 'std'
-        must propagate to:
-          bp-test-utils
-          sp-core
-          sp-io
     crate 'pallet-bridge-relayers'
       feature 'std'
         must propagate to:
-          pallet-balances
           pallet-bridge-messages
-          sp-core
-          sp-io
-    crate 'pallet-collator-selection'
-      feature 'std'
-        must propagate to:
-          pallet-aura
-          pallet-balances
-          pallet-timestamp
-          sp-consensus-aura
-          sp-core
-          sp-io
-          sp-tracing
     crate 'pallet-parachain-template'
       feature 'std'
         must propagate to:
           sp-core
           sp-io
           sp-runtime
-    crate 'pallet-xcm'
-      feature 'std'
-        must propagate to:
-          pallet-balances
-          polkadot-parachain
-          polkadot-runtime-parachains
-          xcm-builder
-    crate 'pallet-xcm-benchmarks'
-      feature 'std'
-        must propagate to:
-          pallet-assets
-          pallet-balances
-          pallet-xcm
-          polkadot-primitives
-          polkadot-runtime-common
-          sp-core
-          sp-tracing
-          xcm
-    crate 'pallet-xcm-bridge-hub-router'
-      feature 'std'
-        must propagate to:
-          sp-io
     crate 'parachain-info'
       feature 'std'
         must propagate to:
@@ -263,7 +182,6 @@ cases:
       feature 'std'
         must propagate to:
           sp-core
-          sp-tracing
     crate 'penpal-runtime'
       feature 'std'
         must propagate to:
@@ -272,10 +190,6 @@ cases:
           frame-system-benchmarking
           frame-try-runtime
           sp-storage
-    crate 'polkadot-primitives'
-      feature 'std'
-        must propagate to:
-          sp-keystore
     crate 'polkadot-runtime'
       feature 'std'
         must propagate to:
@@ -290,15 +204,11 @@ cases:
           sp-io
           sp-storage
           sp-tracing
-          sp-trie
     crate 'polkadot-runtime-common'
       feature 'std'
         must propagate to:
           frame-benchmarking
           frame-election-provider-support
-          frame-support-test
-          pallet-babe
-          sp-keystore
     crate 'polkadot-runtime-metrics'
       feature 'std'
         must propagate to:
@@ -307,17 +217,13 @@ cases:
       feature 'std'
         must propagate to:
           frame-benchmarking
-          frame-support-test
           polkadot-parachain
           sp-application-crypto
-          sp-keystore
-          sp-tracing
     crate 'polkadot-test-runtime'
       feature 'std'
         must propagate to:
           polkadot-runtime-parachains
           sp-mmr-primitives
-          sp-trie
     crate 'rococo-parachain-runtime'
       feature 'std'
         must propagate to:
@@ -332,7 +238,6 @@ cases:
           pallet-xcm-benchmarks
           sp-storage
           sp-tracing
-          sp-trie
     crate 'shell-runtime'
       feature 'std'
         must propagate to:
@@ -345,10 +250,6 @@ cases:
       feature 'std'
         must propagate to:
           sp-io
-    crate 'test-parachains'
-      feature 'std'
-        must propagate to:
-          sp-core
     crate 'westend-runtime'
       feature 'std'
         must propagate to:
@@ -362,32 +263,9 @@ cases:
           pallet-xcm-benchmarks
           sp-storage
           sp-tracing
-    crate 'xcm'
-      feature 'std'
-        must propagate to:
-          sp-io
-    crate 'xcm-builder'
-      feature 'std'
-        must propagate to:
-          pallet-assets
-          pallet-balances
-          pallet-salary
-          pallet-xcm
-          primitives (renamed from polkadot-primitives)
-          polkadot-runtime-parachains
-          polkadot-test-runtime
-    crate 'xcm-executor-integration-tests'
-      feature 'std'
-        must propagate to:
-          frame-system
-          pallet-xcm
-          polkadot-test-runtime
-          sp-state-machine
-          sp-tracing
-          xcm-executor
-    Found 219 issues and fixed 219.
+    Found 139 issues and fixed 139.
   code: 0
-  diff: "diff --git cumulus/bridges/bin/runtime-common/Cargo.toml cumulus/bridges/bin/runtime-common/Cargo.toml\nindex ee1334..bf2161 100644\n--- cumulus/bridges/bin/runtime-common/Cargo.toml\n+++ cumulus/bridges/bin/runtime-common/Cargo.toml\n@@ -79,0 +80,3 @@ std = [\n+\t\"bp-relayers/std\",\n+\t\"bp-test-utils/std\",\n+\t\"pallet-balances/std\"\ndiff --git cumulus/bridges/modules/grandpa/Cargo.toml cumulus/bridges/modules/grandpa/Cargo.toml\nindex 3e25b5..691fce 100644\n--- cumulus/bridges/modules/grandpa/Cargo.toml\n+++ cumulus/bridges/modules/grandpa/Cargo.toml\n@@ -54,0 +55,2 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/modules/messages/Cargo.toml cumulus/bridges/modules/messages/Cargo.toml\nindex 8108b5..5ddf98 100644\n--- cumulus/bridges/modules/messages/Cargo.toml\n+++ cumulus/bridges/modules/messages/Cargo.toml\n@@ -48,0 +49,3 @@ std = [\n+\t\"bp-test-utils/std\",\n+\t\"pallet-balances/std\",\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/modules/parachains/Cargo.toml cumulus/bridges/modules/parachains/Cargo.toml\nindex d7384c..4a399b 100644\n--- cumulus/bridges/modules/parachains/Cargo.toml\n+++ cumulus/bridges/modules/parachains/Cargo.toml\n@@ -52,0 +53,3 @@ std = [\n+\t\"bp-test-utils/std\",\n+\t\"sp-core/std\",\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/modules/relayers/Cargo.toml cumulus/bridges/modules/relayers/Cargo.toml\nindex 8a5a4e..328d5f 100644\n--- cumulus/bridges/modules/relayers/Cargo.toml\n+++ cumulus/bridges/modules/relayers/Cargo.toml\n@@ -51,0 +52,4 @@ std = [\n+\t\"pallet-balances/std\",\n+\t\"pallet-bridge-messages/std\",\n+\t\"sp-core/std\",\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\nindex 7f57c5..addb05 100644\n--- cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\n+++ cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\n@@ -50,0 +51 @@ std = [\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/primitives/header-chain/Cargo.toml cumulus/bridges/primitives/header-chain/Cargo.toml\nindex 8b59a2..e704f1 100644\n--- cumulus/bridges/primitives/header-chain/Cargo.toml\n+++ cumulus/bridges/primitives/header-chain/Cargo.toml\n@@ -44,0 +45 @@ std = [\n+\t\"bp-test-utils/std\"\ndiff --git cumulus/bridges/primitives/test-utils/Cargo.toml cumulus/bridges/primitives/test-utils/Cargo.toml\nindex e841c8..8be857 100644\n--- cumulus/bridges/primitives/test-utils/Cargo.toml\n+++ cumulus/bridges/primitives/test-utils/Cargo.toml\n@@ -35,0 +36,3 @@ std = [\n+\t\"bp-parachains/std\",\n+\t\"bp-runtime/std\",\n+\t\"sp-trie/std\"\ndiff --git cumulus/pallets/aura-ext/Cargo.toml cumulus/pallets/aura-ext/Cargo.toml\nindex b29bbe..642766 100644\n--- cumulus/pallets/aura-ext/Cargo.toml\n+++ cumulus/pallets/aura-ext/Cargo.toml\n@@ -42,0 +43 @@ std = [\n+\t\"pallet-timestamp/std\"\ndiff --git cumulus/pallets/collator-selection/Cargo.toml cumulus/pallets/collator-selection/Cargo.toml\nindex cce7e3..782aad 100644\n--- cumulus/pallets/collator-selection/Cargo.toml\n+++ cumulus/pallets/collator-selection/Cargo.toml\n@@ -60,0 +61,7 @@ std = [\n+\t\"pallet-aura/std\",\n+\t\"pallet-balances/std\",\n+\t\"pallet-timestamp/std\",\n+\t\"sp-consensus-aura/std\",\n+\t\"sp-core/std\",\n+\t\"sp-io/std\",\n+\t\"sp-tracing/std\"\ndiff --git cumulus/pallets/dmp-queue/Cargo.toml cumulus/pallets/dmp-queue/Cargo.toml\nindex 377738..4d3601 100644\n--- cumulus/pallets/dmp-queue/Cargo.toml\n+++ cumulus/pallets/dmp-queue/Cargo.toml\n@@ -41,0 +42,2 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-version/std\"\ndiff --git cumulus/pallets/parachain-system/Cargo.toml cumulus/pallets/parachain-system/Cargo.toml\nindex cfc439..c5f4c6 100644\n--- cumulus/pallets/parachain-system/Cargo.toml\n+++ cumulus/pallets/parachain-system/Cargo.toml\n@@ -74,0 +75,5 @@ std = [\n+\t\"cumulus-test-relay-sproof-builder/std\",\n+\t\"polkadot-parachain/std\",\n+\t\"sp-inherents/std\",\n+\t\"sp-tracing/std\",\n+\t\"sp-version/std\"\ndiff --git cumulus/pallets/xcm/Cargo.toml cumulus/pallets/xcm/Cargo.toml\nindex d6b8c6..447a57 100644\n--- cumulus/pallets/xcm/Cargo.toml\n+++ cumulus/pallets/xcm/Cargo.toml\n@@ -31,0 +32 @@ std = [\n+\t\"sp-io/std\"\ndiff --git cumulus/pallets/xcmp-queue/Cargo.toml cumulus/pallets/xcmp-queue/Cargo.toml\nindex 2cd319..0b0cb0 100644\n--- cumulus/pallets/xcmp-queue/Cargo.toml\n+++ cumulus/pallets/xcmp-queue/Cargo.toml\n@@ -57,0 +58,5 @@ std = [\n+\t\"cumulus-pallet-parachain-system/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"pallet-balances/std\",\n+\t\"sp-core/std\",\n+\t\"xcm-builder/std\"\ndiff --git cumulus/parachain-template/pallets/template/Cargo.toml cumulus/parachain-template/pallets/template/Cargo.toml\nindex 9235cb..2cbfac 100644\n--- cumulus/parachain-template/pallets/template/Cargo.toml\n+++ cumulus/parachain-template/pallets/template/Cargo.toml\n@@ -39,0 +40,3 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-io/std\",\n+\t\"sp-runtime/std\"\ndiff --git cumulus/parachain-template/runtime/Cargo.toml cumulus/parachain-template/runtime/Cargo.toml\nindex c61df9..c7b97b 100644\n--- cumulus/parachain-template/runtime/Cargo.toml\n+++ cumulus/parachain-template/runtime/Cargo.toml\n@@ -120,0 +121,4 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\"\ndiff --git cumulus/parachains/common/Cargo.toml cumulus/parachains/common/Cargo.toml\nindex 5900ec..3b1120 100644\n--- cumulus/parachains/common/Cargo.toml\n+++ cumulus/parachains/common/Cargo.toml\n@@ -65,0 +66,4 @@ std = [\n+\t\"pallet-asset-tx-payment/std\",\n+\t\"sp-core/std\",\n+\t\"sp-runtime/std\",\n+\t\"xcm-builder/std\"\ndiff --git cumulus/parachains/pallets/parachain-info/Cargo.toml cumulus/parachains/pallets/parachain-info/Cargo.toml\nindex 11876b..2be2f5 100644\n--- cumulus/parachains/pallets/parachain-info/Cargo.toml\n+++ cumulus/parachains/pallets/parachain-info/Cargo.toml\n@@ -27,0 +28,2 @@ std = [\n+\t\"sp-runtime/std\",\n+\t\"sp-std/std\"\ndiff --git cumulus/parachains/pallets/ping/Cargo.toml cumulus/parachains/pallets/ping/Cargo.toml\nindex d883be..4525c7 100644\n--- cumulus/parachains/pallets/ping/Cargo.toml\n+++ cumulus/parachains/pallets/ping/Cargo.toml\n@@ -31,0 +32 @@ std = [\n+\t\"cumulus-pallet-xcm/std\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\nindex 682581..ca2ede 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n@@ -209,0 +210,8 @@ std = [\n+\t\"asset-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-weights/std\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\nindex dba374..70c5fa 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n@@ -189,0 +190,8 @@ std = [\n+\t\"asset-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-weights/std\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\nindex 1e9c49..9950a4 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n@@ -199,0 +200,8 @@ std = [\n+\t\"asset-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-io/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/assets/test-utils/Cargo.toml cumulus/parachains/runtimes/assets/test-utils/Cargo.toml\nindex 919f1b..1e8b04 100644\n--- cumulus/parachains/runtimes/assets/test-utils/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/test-utils/Cargo.toml\n@@ -75,0 +76 @@ std = [\n+\t\"sp-core/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\nindex 0dbe3e..d5f170 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n@@ -127,0 +128,7 @@ std = [\n+\t\"bridge-hub-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\nindex 9243f2..b8ff6c 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n@@ -127,0 +128,7 @@ std = [\n+\t\"bridge-hub-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\nindex 5e049d..16adef 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n@@ -163,0 +164,6 @@ std = [\n+\t\"bridge-hub-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml\nindex 1efa80..4565b5 100644\n--- cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml\n@@ -98,0 +99,2 @@ std = [\n+\t\"pallet-collator-selection/std\",\n+\t\"pallet-xcm-benchmarks?/std\"\ndiff --git cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\nindex 3d2f6e..7bf470 100644\n--- cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n@@ -197,0 +198,7 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"sp-arithmetic/std\",\n+\t\"sp-io/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\nindex 67885d..904e01 100644\n--- cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n@@ -130,0 +131,4 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\nindex 43bf46..924b8a 100644\n--- cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n@@ -85,0 +86,4 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/starters/shell/Cargo.toml cumulus/parachains/runtimes/starters/shell/Cargo.toml\nindex d15270..7a0ae5 100644\n--- cumulus/parachains/runtimes/starters/shell/Cargo.toml\n+++ cumulus/parachains/runtimes/starters/shell/Cargo.toml\n@@ -68,0 +69 @@ std = [\n+\t\"frame-try-runtime?/std\"\ndiff --git cumulus/parachains/runtimes/test-utils/Cargo.toml cumulus/parachains/runtimes/test-utils/Cargo.toml\nindex 6fbda8..3e0388 100644\n--- cumulus/parachains/runtimes/test-utils/Cargo.toml\n+++ cumulus/parachains/runtimes/test-utils/Cargo.toml\n@@ -74,0 +75,2 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-tracing/std\"\ndiff --git cumulus/parachains/runtimes/testing/penpal/Cargo.toml cumulus/parachains/runtimes/testing/penpal/Cargo.toml\nindex dc945a..032592 100644\n--- cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n+++ cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n@@ -125,0 +126,5 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\nindex 9a16d3..083621 100644\n--- cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\n+++ cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\n@@ -100,0 +101,2 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"polkadot-parachain/std\"\ndiff --git cumulus/primitives/core/Cargo.toml cumulus/primitives/core/Cargo.toml\nindex 872278..6f306c 100644\n--- cumulus/primitives/core/Cargo.toml\n+++ cumulus/primitives/core/Cargo.toml\n@@ -34,0 +35 @@ std = [\n+\t\"xcm/std\"\ndiff --git cumulus/primitives/parachain-inherent/Cargo.toml cumulus/primitives/parachain-inherent/Cargo.toml\nindex ffcc0a..e3afb7 100644\n--- cumulus/primitives/parachain-inherent/Cargo.toml\n+++ cumulus/primitives/parachain-inherent/Cargo.toml\n@@ -47,0 +48,5 @@ std = [\n+\t\"cumulus-test-relay-sproof-builder?/std\",\n+\t\"sp-api?/std\",\n+\t\"sp-runtime?/std\",\n+\t\"sp-state-machine?/std\",\n+\t\"sp-storage?/std\"\ndiff --git cumulus/test/relay-sproof-builder/Cargo.toml cumulus/test/relay-sproof-builder/Cargo.toml\nindex 1f7aaf..fe7779 100644\n--- cumulus/test/relay-sproof-builder/Cargo.toml\n+++ cumulus/test/relay-sproof-builder/Cargo.toml\n@@ -30,0 +31 @@ std = [\n+\t\"polkadot-primitives/std\"\ndiff --git polkadot/parachain/test-parachains/Cargo.toml polkadot/parachain/test-parachains/Cargo.toml\nindex fdc3c7..503a14 100644\n--- polkadot/parachain/test-parachains/Cargo.toml\n+++ polkadot/parachain/test-parachains/Cargo.toml\n@@ -22 +22,5 @@ default = [ \"std\" ]\n-std = [ \"adder/std\", \"halt/std\" ]\n+std = [\n+\t\"adder/std\",\n+\t\"halt/std\", \n+\t\"sp-core/std\"\n+]\ndiff --git polkadot/parachain/test-parachains/adder/Cargo.toml polkadot/parachain/test-parachains/adder/Cargo.toml\nindex ca477e..3bda9f 100644\n--- polkadot/parachain/test-parachains/adder/Cargo.toml\n+++ polkadot/parachain/test-parachains/adder/Cargo.toml\n@@ -26 +26,5 @@ default = [ \"std\" ]\n-std = [ \"parachain/std\", \"sp-std/std\" ]\n+std = [\n+\t\"parachain/std\",\n+\t\"sp-std/std\", \n+\t\"sp-io/std\"\n+]\ndiff --git polkadot/parachain/test-parachains/undying/Cargo.toml polkadot/parachain/test-parachains/undying/Cargo.toml\nindex 192e89..2a0607 100644\n--- polkadot/parachain/test-parachains/undying/Cargo.toml\n+++ polkadot/parachain/test-parachains/undying/Cargo.toml\n@@ -27 +27,5 @@ default = [ \"std\" ]\n-std = [ \"parachain/std\", \"sp-std/std\" ]\n+std = [\n+\t\"parachain/std\",\n+\t\"sp-std/std\", \n+\t\"sp-io/std\"\n+]\ndiff --git polkadot/primitives/Cargo.toml polkadot/primitives/Cargo.toml\nindex be0531..fd55c6 100644\n--- polkadot/primitives/Cargo.toml\n+++ polkadot/primitives/Cargo.toml\n@@ -51,0 +52 @@ std = [\n+\t\"sp-keystore?/std\"\ndiff --git polkadot/runtime/common/Cargo.toml polkadot/runtime/common/Cargo.toml\nindex 72b077..0b9f01 100644\n--- polkadot/runtime/common/Cargo.toml\n+++ polkadot/runtime/common/Cargo.toml\n@@ -102,0 +103,5 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-election-provider-support/std\",\n+\t\"frame-support-test/std\",\n+\t\"pallet-babe?/std\",\n+\t\"sp-keystore/std\"\ndiff --git polkadot/runtime/kusama/Cargo.toml polkadot/runtime/kusama/Cargo.toml\nindex d04f67..252830 100644\n--- polkadot/runtime/kusama/Cargo.toml\n+++ polkadot/runtime/kusama/Cargo.toml\n@@ -217,0 +218,11 @@ std = [\n+\t\"binary-merkle-tree/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-election-provider-support-benchmarking?/std\",\n+\t\"pallet-nomination-pools-benchmarking?/std\",\n+\t\"pallet-offences-benchmarking?/std\",\n+\t\"pallet-session-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\",\n+\t\"sp-trie/std\"\ndiff --git polkadot/runtime/metrics/Cargo.toml polkadot/runtime/metrics/Cargo.toml\nindex de3114..9d88df 100644\n--- polkadot/runtime/metrics/Cargo.toml\n+++ polkadot/runtime/metrics/Cargo.toml\n@@ -24,0 +25 @@ std = [\n+\t\"frame-benchmarking?/std\"\ndiff --git polkadot/runtime/parachains/Cargo.toml polkadot/runtime/parachains/Cargo.toml\nindex f4f647..22f584 100644\n--- polkadot/runtime/parachains/Cargo.toml\n+++ polkadot/runtime/parachains/Cargo.toml\n@@ -98,0 +99,6 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-support-test/std\",\n+\t\"polkadot-parachain/std\",\n+\t\"sp-application-crypto?/std\",\n+\t\"sp-keystore?/std\",\n+\t\"sp-tracing?/std\"\ndiff --git polkadot/runtime/polkadot/Cargo.toml polkadot/runtime/polkadot/Cargo.toml\nindex 1d2ce8..d3c0e9 100644\n--- polkadot/runtime/polkadot/Cargo.toml\n+++ polkadot/runtime/polkadot/Cargo.toml\n@@ -199,0 +200,12 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-election-provider-support-benchmarking?/std\",\n+\t\"pallet-nomination-pools-benchmarking?/std\",\n+\t\"pallet-offences-benchmarking?/std\",\n+\t\"pallet-session-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"runtime-parachains/std\",\n+\t\"sp-io/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\",\n+\t\"sp-trie/std\"\ndiff --git polkadot/runtime/rococo/Cargo.toml polkadot/runtime/rococo/Cargo.toml\nindex ebb7cd..2a54bf 100644\n--- polkadot/runtime/rococo/Cargo.toml\n+++ polkadot/runtime/rococo/Cargo.toml\n@@ -184,0 +185,7 @@ std = [\n+\t\"binary-merkle-tree/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\",\n+\t\"sp-trie/std\"\ndiff --git polkadot/runtime/test-runtime/Cargo.toml polkadot/runtime/test-runtime/Cargo.toml\nindex e5d04a..258920 100644\n--- polkadot/runtime/test-runtime/Cargo.toml\n+++ polkadot/runtime/test-runtime/Cargo.toml\n@@ -136,0 +137,3 @@ std = [\n+\t\"polkadot-runtime-parachains/std\",\n+\t\"sp-mmr-primitives/std\",\n+\t\"sp-trie/std\"\ndiff --git polkadot/runtime/westend/Cargo.toml polkadot/runtime/westend/Cargo.toml\nindex 40664e..f43a8b 100644\n--- polkadot/runtime/westend/Cargo.toml\n+++ polkadot/runtime/westend/Cargo.toml\n@@ -202,0 +203,10 @@ std = [\n+\t\"binary-merkle-tree/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-election-provider-support-benchmarking?/std\",\n+\t\"pallet-nomination-pools-benchmarking?/std\",\n+\t\"pallet-offences-benchmarking?/std\",\n+\t\"pallet-session-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\"\ndiff --git polkadot/xcm/Cargo.toml polkadot/xcm/Cargo.toml\nindex d33b1b..2f2388 100644\n--- polkadot/xcm/Cargo.toml\n+++ polkadot/xcm/Cargo.toml\n@@ -33,0 +34 @@ std = [\n+\t\"sp-io/std\"\ndiff --git polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml\nindex f6f993..672bb4 100644\n--- polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml\n+++ polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml\n@@ -48,0 +49,8 @@ std = [\n+\t\"pallet-assets/std\",\n+\t\"pallet-balances/std\",\n+\t\"pallet-xcm/std\",\n+\t\"polkadot-primitives/std\",\n+\t\"polkadot-runtime-common/std\",\n+\t\"sp-core/std\",\n+\t\"sp-tracing/std\",\n+\t\"xcm/std\"\ndiff --git polkadot/xcm/pallet-xcm/Cargo.toml polkadot/xcm/pallet-xcm/Cargo.toml\nindex eefc3c..57e471 100644\n--- polkadot/xcm/pallet-xcm/Cargo.toml\n+++ polkadot/xcm/pallet-xcm/Cargo.toml\n@@ -50,0 +51,4 @@ std = [\n+\t\"pallet-balances/std\",\n+\t\"polkadot-parachain/std\",\n+\t\"polkadot-runtime-parachains/std\",\n+\t\"xcm-builder/std\"\ndiff --git polkadot/xcm/xcm-builder/Cargo.toml polkadot/xcm/xcm-builder/Cargo.toml\nindex 336162..2cd29a 100644\n--- polkadot/xcm/xcm-builder/Cargo.toml\n+++ polkadot/xcm/xcm-builder/Cargo.toml\n@@ -61,0 +62,7 @@ std = [\n+\t\"pallet-assets/std\",\n+\t\"pallet-balances/std\",\n+\t\"pallet-salary/std\",\n+\t\"pallet-xcm/std\",\n+\t\"primitives/std\",\n+\t\"polkadot-runtime-parachains/std\",\n+\t\"polkadot-test-runtime/std\"\ndiff --git polkadot/xcm/xcm-executor/integration-tests/Cargo.toml polkadot/xcm/xcm-executor/integration-tests/Cargo.toml\nindex ecd709..b05bfa 100644\n--- polkadot/xcm/xcm-executor/integration-tests/Cargo.toml\n+++ polkadot/xcm/xcm-executor/integration-tests/Cargo.toml\n@@ -29 +29,11 @@ default = [ \"std\" ]\n-std = [ \"frame-support/std\", \"sp-runtime/std\", \"xcm/std\" ]\n+std = [\n+\t\"frame-support/std\",\n+\t\"sp-runtime/std\",\n+\t\"xcm/std\",\n+\t\"frame-system/std\",\n+\t\"pallet-xcm/std\",\n+\t\"polkadot-test-runtime/std\",\n+\t\"sp-state-machine/std\",\n+\t\"sp-tracing/std\",\n+\t\"xcm-executor/std\"\n+]\n"
+  diff: "diff --git cumulus/bridges/bin/runtime-common/Cargo.toml cumulus/bridges/bin/runtime-common/Cargo.toml\nindex ee1334..cc552e 100644\n--- cumulus/bridges/bin/runtime-common/Cargo.toml\n+++ cumulus/bridges/bin/runtime-common/Cargo.toml\n@@ -79,0 +80 @@ std = [\n+\t\"bp-relayers/std\"\ndiff --git cumulus/bridges/modules/relayers/Cargo.toml cumulus/bridges/modules/relayers/Cargo.toml\nindex 8a5a4e..f7fd68 100644\n--- cumulus/bridges/modules/relayers/Cargo.toml\n+++ cumulus/bridges/modules/relayers/Cargo.toml\n@@ -51,0 +52 @@ std = [\n+\t\"pallet-bridge-messages/std\"\ndiff --git cumulus/bridges/primitives/test-utils/Cargo.toml cumulus/bridges/primitives/test-utils/Cargo.toml\nindex e841c8..8be857 100644\n--- cumulus/bridges/primitives/test-utils/Cargo.toml\n+++ cumulus/bridges/primitives/test-utils/Cargo.toml\n@@ -35,0 +36,3 @@ std = [\n+\t\"bp-parachains/std\",\n+\t\"bp-runtime/std\",\n+\t\"sp-trie/std\"\ndiff --git cumulus/pallets/aura-ext/Cargo.toml cumulus/pallets/aura-ext/Cargo.toml\nindex b29bbe..642766 100644\n--- cumulus/pallets/aura-ext/Cargo.toml\n+++ cumulus/pallets/aura-ext/Cargo.toml\n@@ -42,0 +43 @@ std = [\n+\t\"pallet-timestamp/std\"\ndiff --git cumulus/pallets/dmp-queue/Cargo.toml cumulus/pallets/dmp-queue/Cargo.toml\nindex 377738..4d3601 100644\n--- cumulus/pallets/dmp-queue/Cargo.toml\n+++ cumulus/pallets/dmp-queue/Cargo.toml\n@@ -41,0 +42,2 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-version/std\"\ndiff --git cumulus/pallets/parachain-system/Cargo.toml cumulus/pallets/parachain-system/Cargo.toml\nindex cfc439..4aff6b 100644\n--- cumulus/pallets/parachain-system/Cargo.toml\n+++ cumulus/pallets/parachain-system/Cargo.toml\n@@ -74,0 +75,2 @@ std = [\n+\t\"polkadot-parachain/std\",\n+\t\"sp-inherents/std\"\ndiff --git cumulus/pallets/xcm/Cargo.toml cumulus/pallets/xcm/Cargo.toml\nindex d6b8c6..447a57 100644\n--- cumulus/pallets/xcm/Cargo.toml\n+++ cumulus/pallets/xcm/Cargo.toml\n@@ -31,0 +32 @@ std = [\n+\t\"sp-io/std\"\ndiff --git cumulus/pallets/xcmp-queue/Cargo.toml cumulus/pallets/xcmp-queue/Cargo.toml\nindex 2cd319..9316d4 100644\n--- cumulus/pallets/xcmp-queue/Cargo.toml\n+++ cumulus/pallets/xcmp-queue/Cargo.toml\n@@ -57,0 +58 @@ std = [\n+\t\"frame-benchmarking?/std\"\ndiff --git cumulus/parachain-template/pallets/template/Cargo.toml cumulus/parachain-template/pallets/template/Cargo.toml\nindex 9235cb..2cbfac 100644\n--- cumulus/parachain-template/pallets/template/Cargo.toml\n+++ cumulus/parachain-template/pallets/template/Cargo.toml\n@@ -39,0 +40,3 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-io/std\",\n+\t\"sp-runtime/std\"\ndiff --git cumulus/parachain-template/runtime/Cargo.toml cumulus/parachain-template/runtime/Cargo.toml\nindex c61df9..c7b97b 100644\n--- cumulus/parachain-template/runtime/Cargo.toml\n+++ cumulus/parachain-template/runtime/Cargo.toml\n@@ -120,0 +121,4 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\"\ndiff --git cumulus/parachains/common/Cargo.toml cumulus/parachains/common/Cargo.toml\nindex 5900ec..3b1120 100644\n--- cumulus/parachains/common/Cargo.toml\n+++ cumulus/parachains/common/Cargo.toml\n@@ -65,0 +66,4 @@ std = [\n+\t\"pallet-asset-tx-payment/std\",\n+\t\"sp-core/std\",\n+\t\"sp-runtime/std\",\n+\t\"xcm-builder/std\"\ndiff --git cumulus/parachains/pallets/parachain-info/Cargo.toml cumulus/parachains/pallets/parachain-info/Cargo.toml\nindex 11876b..2be2f5 100644\n--- cumulus/parachains/pallets/parachain-info/Cargo.toml\n+++ cumulus/parachains/pallets/parachain-info/Cargo.toml\n@@ -27,0 +28,2 @@ std = [\n+\t\"sp-runtime/std\",\n+\t\"sp-std/std\"\ndiff --git cumulus/parachains/pallets/ping/Cargo.toml cumulus/parachains/pallets/ping/Cargo.toml\nindex d883be..4525c7 100644\n--- cumulus/parachains/pallets/ping/Cargo.toml\n+++ cumulus/parachains/pallets/ping/Cargo.toml\n@@ -31,0 +32 @@ std = [\n+\t\"cumulus-pallet-xcm/std\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\nindex 682581..e03de7 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n@@ -209,0 +210,7 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-weights/std\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\nindex dba374..f0b804 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n@@ -189,0 +190,7 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-weights/std\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\nindex 1e9c49..c964b3 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n@@ -199,0 +200,6 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/assets/test-utils/Cargo.toml cumulus/parachains/runtimes/assets/test-utils/Cargo.toml\nindex 919f1b..1e8b04 100644\n--- cumulus/parachains/runtimes/assets/test-utils/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/test-utils/Cargo.toml\n@@ -75,0 +76 @@ std = [\n+\t\"sp-core/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\nindex 0dbe3e..d0749d 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n@@ -127,0 +128,6 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\nindex 9243f2..581298 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n@@ -127,0 +128,6 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\nindex 5e049d..8b7e37 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n@@ -163,0 +164,5 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml\nindex 1efa80..4565b5 100644\n--- cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml\n@@ -98,0 +99,2 @@ std = [\n+\t\"pallet-collator-selection/std\",\n+\t\"pallet-xcm-benchmarks?/std\"\ndiff --git cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\nindex 3d2f6e..7bf470 100644\n--- cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n@@ -197,0 +198,7 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"sp-arithmetic/std\",\n+\t\"sp-io/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\nindex 67885d..904e01 100644\n--- cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n@@ -130,0 +131,4 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\nindex 43bf46..924b8a 100644\n--- cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n@@ -85,0 +86,4 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/starters/shell/Cargo.toml cumulus/parachains/runtimes/starters/shell/Cargo.toml\nindex d15270..7a0ae5 100644\n--- cumulus/parachains/runtimes/starters/shell/Cargo.toml\n+++ cumulus/parachains/runtimes/starters/shell/Cargo.toml\n@@ -68,0 +69 @@ std = [\n+\t\"frame-try-runtime?/std\"\ndiff --git cumulus/parachains/runtimes/test-utils/Cargo.toml cumulus/parachains/runtimes/test-utils/Cargo.toml\nindex 6fbda8..8da190 100644\n--- cumulus/parachains/runtimes/test-utils/Cargo.toml\n+++ cumulus/parachains/runtimes/test-utils/Cargo.toml\n@@ -74,0 +75 @@ std = [\n+\t\"sp-core/std\"\ndiff --git cumulus/parachains/runtimes/testing/penpal/Cargo.toml cumulus/parachains/runtimes/testing/penpal/Cargo.toml\nindex dc945a..032592 100644\n--- cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n+++ cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n@@ -125,0 +126,5 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\nindex 9a16d3..083621 100644\n--- cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\n+++ cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\n@@ -100,0 +101,2 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"polkadot-parachain/std\"\ndiff --git cumulus/primitives/core/Cargo.toml cumulus/primitives/core/Cargo.toml\nindex 872278..6f306c 100644\n--- cumulus/primitives/core/Cargo.toml\n+++ cumulus/primitives/core/Cargo.toml\n@@ -34,0 +35 @@ std = [\n+\t\"xcm/std\"\ndiff --git cumulus/test/relay-sproof-builder/Cargo.toml cumulus/test/relay-sproof-builder/Cargo.toml\nindex 1f7aaf..fe7779 100644\n--- cumulus/test/relay-sproof-builder/Cargo.toml\n+++ cumulus/test/relay-sproof-builder/Cargo.toml\n@@ -30,0 +31 @@ std = [\n+\t\"polkadot-primitives/std\"\ndiff --git polkadot/parachain/test-parachains/adder/Cargo.toml polkadot/parachain/test-parachains/adder/Cargo.toml\nindex ca477e..3bda9f 100644\n--- polkadot/parachain/test-parachains/adder/Cargo.toml\n+++ polkadot/parachain/test-parachains/adder/Cargo.toml\n@@ -26 +26,5 @@ default = [ \"std\" ]\n-std = [ \"parachain/std\", \"sp-std/std\" ]\n+std = [\n+\t\"parachain/std\",\n+\t\"sp-std/std\", \n+\t\"sp-io/std\"\n+]\ndiff --git polkadot/parachain/test-parachains/undying/Cargo.toml polkadot/parachain/test-parachains/undying/Cargo.toml\nindex 192e89..2a0607 100644\n--- polkadot/parachain/test-parachains/undying/Cargo.toml\n+++ polkadot/parachain/test-parachains/undying/Cargo.toml\n@@ -27 +27,5 @@ default = [ \"std\" ]\n-std = [ \"parachain/std\", \"sp-std/std\" ]\n+std = [\n+\t\"parachain/std\",\n+\t\"sp-std/std\", \n+\t\"sp-io/std\"\n+]\ndiff --git polkadot/runtime/common/Cargo.toml polkadot/runtime/common/Cargo.toml\nindex 72b077..f397ff 100644\n--- polkadot/runtime/common/Cargo.toml\n+++ polkadot/runtime/common/Cargo.toml\n@@ -102,0 +103,2 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-election-provider-support/std\"\ndiff --git polkadot/runtime/kusama/Cargo.toml polkadot/runtime/kusama/Cargo.toml\nindex d04f67..1f3645 100644\n--- polkadot/runtime/kusama/Cargo.toml\n+++ polkadot/runtime/kusama/Cargo.toml\n@@ -217,0 +218,10 @@ std = [\n+\t\"binary-merkle-tree/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-election-provider-support-benchmarking?/std\",\n+\t\"pallet-nomination-pools-benchmarking?/std\",\n+\t\"pallet-offences-benchmarking?/std\",\n+\t\"pallet-session-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\"\ndiff --git polkadot/runtime/metrics/Cargo.toml polkadot/runtime/metrics/Cargo.toml\nindex de3114..9d88df 100644\n--- polkadot/runtime/metrics/Cargo.toml\n+++ polkadot/runtime/metrics/Cargo.toml\n@@ -24,0 +25 @@ std = [\n+\t\"frame-benchmarking?/std\"\ndiff --git polkadot/runtime/parachains/Cargo.toml polkadot/runtime/parachains/Cargo.toml\nindex f4f647..e1c9fc 100644\n--- polkadot/runtime/parachains/Cargo.toml\n+++ polkadot/runtime/parachains/Cargo.toml\n@@ -98,0 +99,3 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"polkadot-parachain/std\",\n+\t\"sp-application-crypto?/std\"\ndiff --git polkadot/runtime/polkadot/Cargo.toml polkadot/runtime/polkadot/Cargo.toml\nindex 1d2ce8..c37294 100644\n--- polkadot/runtime/polkadot/Cargo.toml\n+++ polkadot/runtime/polkadot/Cargo.toml\n@@ -199,0 +200,11 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-election-provider-support-benchmarking?/std\",\n+\t\"pallet-nomination-pools-benchmarking?/std\",\n+\t\"pallet-offences-benchmarking?/std\",\n+\t\"pallet-session-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"runtime-parachains/std\",\n+\t\"sp-io/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\"\ndiff --git polkadot/runtime/rococo/Cargo.toml polkadot/runtime/rococo/Cargo.toml\nindex ebb7cd..925013 100644\n--- polkadot/runtime/rococo/Cargo.toml\n+++ polkadot/runtime/rococo/Cargo.toml\n@@ -184,0 +185,6 @@ std = [\n+\t\"binary-merkle-tree/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\"\ndiff --git polkadot/runtime/test-runtime/Cargo.toml polkadot/runtime/test-runtime/Cargo.toml\nindex e5d04a..7aab01 100644\n--- polkadot/runtime/test-runtime/Cargo.toml\n+++ polkadot/runtime/test-runtime/Cargo.toml\n@@ -136,0 +137,2 @@ std = [\n+\t\"polkadot-runtime-parachains/std\",\n+\t\"sp-mmr-primitives/std\"\ndiff --git polkadot/runtime/westend/Cargo.toml polkadot/runtime/westend/Cargo.toml\nindex 40664e..f43a8b 100644\n--- polkadot/runtime/westend/Cargo.toml\n+++ polkadot/runtime/westend/Cargo.toml\n@@ -202,0 +203,10 @@ std = [\n+\t\"binary-merkle-tree/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-election-provider-support-benchmarking?/std\",\n+\t\"pallet-nomination-pools-benchmarking?/std\",\n+\t\"pallet-offences-benchmarking?/std\",\n+\t\"pallet-session-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\"\n"
 - cmd: lint propagate-feature --feature try-runtime --left-side-feature-missing=ignore --workspace --fix
   stdout: |
     crate 'asset-hub-kusama-runtime'

--- a/tests/integration/sdk/propagate.yaml
+++ b/tests/integration/sdk/propagate.yaml
@@ -1,0 +1,1053 @@
+repo:
+  name: polkadot-sdk
+  ref: 70ab64bd1593dc15e6813de71f8ba280f2fb56f1
+cases:
+- cmd: lint propagate-feature --feature std --left-side-feature-missing=ignore --workspace --fix
+  stdout: |
+    crate 'asset-hub-kusama-runtime'
+      feature 'std'
+        must propagate to:
+          asset-test-utils
+          cumulus-pallet-session-benchmarking
+          frame-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+          pallet-xcm-benchmarks
+          sp-storage
+          sp-weights
+    crate 'asset-hub-polkadot-runtime'
+      feature 'std'
+        must propagate to:
+          asset-test-utils
+          cumulus-pallet-session-benchmarking
+          frame-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+          pallet-xcm-benchmarks
+          sp-storage
+          sp-weights
+    crate 'asset-hub-westend-runtime'
+      feature 'std'
+        must propagate to:
+          asset-test-utils
+          cumulus-pallet-session-benchmarking
+          frame-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+          pallet-xcm-benchmarks
+          sp-io
+          sp-storage
+    crate 'asset-test-utils'
+      feature 'std'
+        must propagate to:
+          sp-core
+    crate 'bp-header-chain'
+      feature 'std'
+        must propagate to:
+          bp-test-utils
+    crate 'bp-test-utils'
+      feature 'std'
+        must propagate to:
+          bp-parachains
+          bp-runtime
+          sp-trie
+    crate 'bridge-hub-kusama-runtime'
+      feature 'std'
+        must propagate to:
+          bridge-hub-test-utils
+          cumulus-pallet-session-benchmarking
+          frame-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+          pallet-xcm-benchmarks
+          sp-storage
+    crate 'bridge-hub-polkadot-runtime'
+      feature 'std'
+        must propagate to:
+          bridge-hub-test-utils
+          cumulus-pallet-session-benchmarking
+          frame-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+          pallet-xcm-benchmarks
+          sp-storage
+    crate 'bridge-hub-rococo-runtime'
+      feature 'std'
+        must propagate to:
+          bridge-hub-test-utils
+          cumulus-pallet-session-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+          pallet-xcm-benchmarks
+          sp-storage
+    crate 'bridge-hub-test-utils'
+      feature 'std'
+        must propagate to:
+          pallet-collator-selection
+          pallet-xcm-benchmarks
+    crate 'bridge-runtime-common'
+      feature 'std'
+        must propagate to:
+          bp-relayers
+          bp-test-utils
+          pallet-balances
+    crate 'collectives-polkadot-runtime'
+      feature 'std'
+        must propagate to:
+          cumulus-pallet-session-benchmarking
+          frame-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+          sp-arithmetic
+          sp-io
+          sp-storage
+    crate 'contracts-rococo-runtime'
+      feature 'std'
+        must propagate to:
+          cumulus-pallet-session-benchmarking
+          frame-benchmarking
+          frame-system-benchmarking
+          sp-storage
+    crate 'cumulus-pallet-aura-ext'
+      feature 'std'
+        must propagate to:
+          pallet-timestamp
+    crate 'cumulus-pallet-dmp-queue'
+      feature 'std'
+        must propagate to:
+          sp-core
+          sp-version
+    crate 'cumulus-pallet-parachain-system'
+      feature 'std'
+        must propagate to:
+          cumulus-test-relay-sproof-builder
+          polkadot-parachain
+          sp-inherents
+          sp-tracing
+          sp-version
+    crate 'cumulus-pallet-xcm'
+      feature 'std'
+        must propagate to:
+          sp-io
+    crate 'cumulus-pallet-xcmp-queue'
+      feature 'std'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          frame-benchmarking
+          pallet-balances
+          sp-core
+          xcm-builder
+    crate 'cumulus-ping'
+      feature 'std'
+        must propagate to:
+          cumulus-pallet-xcm
+    crate 'cumulus-primitives-core'
+      feature 'std'
+        must propagate to:
+          xcm
+    crate 'cumulus-primitives-parachain-inherent'
+      feature 'std'
+        must propagate to:
+          cumulus-test-relay-sproof-builder
+          sp-api
+          sp-runtime
+          sp-state-machine
+          sp-storage
+    crate 'cumulus-test-relay-sproof-builder'
+      feature 'std'
+        must propagate to:
+          polkadot-primitives
+    crate 'glutton-runtime'
+      feature 'std'
+        must propagate to:
+          frame-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+          sp-storage
+    crate 'kusama-runtime'
+      feature 'std'
+        must propagate to:
+          binary-merkle-tree
+          frame-benchmarking
+          frame-system-benchmarking
+          pallet-election-provider-support-benchmarking
+          pallet-nomination-pools-benchmarking
+          pallet-offences-benchmarking
+          pallet-session-benchmarking
+          pallet-xcm-benchmarks
+          sp-storage
+          sp-tracing
+          sp-trie
+    crate 'pallet-bridge-grandpa'
+      feature 'std'
+        must propagate to:
+          sp-core
+          sp-io
+    crate 'pallet-bridge-messages'
+      feature 'std'
+        must propagate to:
+          bp-test-utils
+          pallet-balances
+          sp-io
+    crate 'pallet-bridge-parachains'
+      feature 'std'
+        must propagate to:
+          bp-test-utils
+          sp-core
+          sp-io
+    crate 'pallet-bridge-relayers'
+      feature 'std'
+        must propagate to:
+          pallet-balances
+          pallet-bridge-messages
+          sp-core
+          sp-io
+    crate 'pallet-collator-selection'
+      feature 'std'
+        must propagate to:
+          pallet-aura
+          pallet-balances
+          pallet-timestamp
+          sp-consensus-aura
+          sp-core
+          sp-io
+          sp-tracing
+    crate 'pallet-parachain-template'
+      feature 'std'
+        must propagate to:
+          sp-core
+          sp-io
+          sp-runtime
+    crate 'pallet-xcm'
+      feature 'std'
+        must propagate to:
+          pallet-balances
+          polkadot-parachain
+          polkadot-runtime-parachains
+          xcm-builder
+    crate 'pallet-xcm-benchmarks'
+      feature 'std'
+        must propagate to:
+          pallet-assets
+          pallet-balances
+          pallet-xcm
+          polkadot-primitives
+          polkadot-runtime-common
+          sp-core
+          sp-tracing
+          xcm
+    crate 'pallet-xcm-bridge-hub-router'
+      feature 'std'
+        must propagate to:
+          sp-io
+    crate 'parachain-info'
+      feature 'std'
+        must propagate to:
+          sp-runtime
+          sp-std
+    crate 'parachain-template-runtime'
+      feature 'std'
+        must propagate to:
+          cumulus-pallet-session-benchmarking
+          frame-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+    crate 'parachains-common'
+      feature 'std'
+        must propagate to:
+          pallet-asset-tx-payment
+          sp-core
+          sp-runtime
+          xcm-builder
+    crate 'parachains-runtimes-test-utils'
+      feature 'std'
+        must propagate to:
+          sp-core
+          sp-tracing
+    crate 'penpal-runtime'
+      feature 'std'
+        must propagate to:
+          cumulus-pallet-session-benchmarking
+          frame-benchmarking
+          frame-system-benchmarking
+          frame-try-runtime
+          sp-storage
+    crate 'polkadot-primitives'
+      feature 'std'
+        must propagate to:
+          sp-keystore
+    crate 'polkadot-runtime'
+      feature 'std'
+        must propagate to:
+          frame-benchmarking
+          frame-system-benchmarking
+          pallet-election-provider-support-benchmarking
+          pallet-nomination-pools-benchmarking
+          pallet-offences-benchmarking
+          pallet-session-benchmarking
+          pallet-xcm-benchmarks
+          runtime-parachains (renamed from polkadot-runtime-parachains)
+          sp-io
+          sp-storage
+          sp-tracing
+          sp-trie
+    crate 'polkadot-runtime-common'
+      feature 'std'
+        must propagate to:
+          frame-benchmarking
+          frame-election-provider-support
+          frame-support-test
+          pallet-babe
+          sp-keystore
+    crate 'polkadot-runtime-metrics'
+      feature 'std'
+        must propagate to:
+          frame-benchmarking
+    crate 'polkadot-runtime-parachains'
+      feature 'std'
+        must propagate to:
+          frame-benchmarking
+          frame-support-test
+          polkadot-parachain
+          sp-application-crypto
+          sp-keystore
+          sp-tracing
+    crate 'polkadot-test-runtime'
+      feature 'std'
+        must propagate to:
+          polkadot-runtime-parachains
+          sp-mmr-primitives
+          sp-trie
+    crate 'rococo-parachain-runtime'
+      feature 'std'
+        must propagate to:
+          frame-benchmarking
+          polkadot-parachain
+    crate 'rococo-runtime'
+      feature 'std'
+        must propagate to:
+          binary-merkle-tree
+          frame-benchmarking
+          frame-system-benchmarking
+          pallet-xcm-benchmarks
+          sp-storage
+          sp-tracing
+          sp-trie
+    crate 'shell-runtime'
+      feature 'std'
+        must propagate to:
+          frame-try-runtime
+    crate 'test-parachain-adder'
+      feature 'std'
+        must propagate to:
+          sp-io
+    crate 'test-parachain-undying'
+      feature 'std'
+        must propagate to:
+          sp-io
+    crate 'test-parachains'
+      feature 'std'
+        must propagate to:
+          sp-core
+    crate 'westend-runtime'
+      feature 'std'
+        must propagate to:
+          binary-merkle-tree
+          frame-benchmarking
+          frame-system-benchmarking
+          pallet-election-provider-support-benchmarking
+          pallet-nomination-pools-benchmarking
+          pallet-offences-benchmarking
+          pallet-session-benchmarking
+          pallet-xcm-benchmarks
+          sp-storage
+          sp-tracing
+    crate 'xcm'
+      feature 'std'
+        must propagate to:
+          sp-io
+    crate 'xcm-builder'
+      feature 'std'
+        must propagate to:
+          pallet-assets
+          pallet-balances
+          pallet-salary
+          pallet-xcm
+          primitives (renamed from polkadot-primitives)
+          polkadot-runtime-parachains
+          polkadot-test-runtime
+    crate 'xcm-executor-integration-tests'
+      feature 'std'
+        must propagate to:
+          frame-system
+          pallet-xcm
+          polkadot-test-runtime
+          sp-state-machine
+          sp-tracing
+          xcm-executor
+    Found 219 issues and fixed 219.
+  code: 0
+  diff: "diff --git cumulus/bridges/bin/runtime-common/Cargo.toml cumulus/bridges/bin/runtime-common/Cargo.toml\nindex ee1334..bf2161 100644\n--- cumulus/bridges/bin/runtime-common/Cargo.toml\n+++ cumulus/bridges/bin/runtime-common/Cargo.toml\n@@ -79,0 +80,3 @@ std = [\n+\t\"bp-relayers/std\",\n+\t\"bp-test-utils/std\",\n+\t\"pallet-balances/std\"\ndiff --git cumulus/bridges/modules/grandpa/Cargo.toml cumulus/bridges/modules/grandpa/Cargo.toml\nindex 3e25b5..691fce 100644\n--- cumulus/bridges/modules/grandpa/Cargo.toml\n+++ cumulus/bridges/modules/grandpa/Cargo.toml\n@@ -54,0 +55,2 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/modules/messages/Cargo.toml cumulus/bridges/modules/messages/Cargo.toml\nindex 8108b5..5ddf98 100644\n--- cumulus/bridges/modules/messages/Cargo.toml\n+++ cumulus/bridges/modules/messages/Cargo.toml\n@@ -48,0 +49,3 @@ std = [\n+\t\"bp-test-utils/std\",\n+\t\"pallet-balances/std\",\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/modules/parachains/Cargo.toml cumulus/bridges/modules/parachains/Cargo.toml\nindex d7384c..4a399b 100644\n--- cumulus/bridges/modules/parachains/Cargo.toml\n+++ cumulus/bridges/modules/parachains/Cargo.toml\n@@ -52,0 +53,3 @@ std = [\n+\t\"bp-test-utils/std\",\n+\t\"sp-core/std\",\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/modules/relayers/Cargo.toml cumulus/bridges/modules/relayers/Cargo.toml\nindex 8a5a4e..328d5f 100644\n--- cumulus/bridges/modules/relayers/Cargo.toml\n+++ cumulus/bridges/modules/relayers/Cargo.toml\n@@ -51,0 +52,4 @@ std = [\n+\t\"pallet-balances/std\",\n+\t\"pallet-bridge-messages/std\",\n+\t\"sp-core/std\",\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\nindex 7f57c5..addb05 100644\n--- cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\n+++ cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\n@@ -50,0 +51 @@ std = [\n+\t\"sp-io/std\"\ndiff --git cumulus/bridges/primitives/header-chain/Cargo.toml cumulus/bridges/primitives/header-chain/Cargo.toml\nindex 8b59a2..e704f1 100644\n--- cumulus/bridges/primitives/header-chain/Cargo.toml\n+++ cumulus/bridges/primitives/header-chain/Cargo.toml\n@@ -44,0 +45 @@ std = [\n+\t\"bp-test-utils/std\"\ndiff --git cumulus/bridges/primitives/test-utils/Cargo.toml cumulus/bridges/primitives/test-utils/Cargo.toml\nindex e841c8..8be857 100644\n--- cumulus/bridges/primitives/test-utils/Cargo.toml\n+++ cumulus/bridges/primitives/test-utils/Cargo.toml\n@@ -35,0 +36,3 @@ std = [\n+\t\"bp-parachains/std\",\n+\t\"bp-runtime/std\",\n+\t\"sp-trie/std\"\ndiff --git cumulus/pallets/aura-ext/Cargo.toml cumulus/pallets/aura-ext/Cargo.toml\nindex b29bbe..642766 100644\n--- cumulus/pallets/aura-ext/Cargo.toml\n+++ cumulus/pallets/aura-ext/Cargo.toml\n@@ -42,0 +43 @@ std = [\n+\t\"pallet-timestamp/std\"\ndiff --git cumulus/pallets/collator-selection/Cargo.toml cumulus/pallets/collator-selection/Cargo.toml\nindex cce7e3..782aad 100644\n--- cumulus/pallets/collator-selection/Cargo.toml\n+++ cumulus/pallets/collator-selection/Cargo.toml\n@@ -60,0 +61,7 @@ std = [\n+\t\"pallet-aura/std\",\n+\t\"pallet-balances/std\",\n+\t\"pallet-timestamp/std\",\n+\t\"sp-consensus-aura/std\",\n+\t\"sp-core/std\",\n+\t\"sp-io/std\",\n+\t\"sp-tracing/std\"\ndiff --git cumulus/pallets/dmp-queue/Cargo.toml cumulus/pallets/dmp-queue/Cargo.toml\nindex 377738..4d3601 100644\n--- cumulus/pallets/dmp-queue/Cargo.toml\n+++ cumulus/pallets/dmp-queue/Cargo.toml\n@@ -41,0 +42,2 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-version/std\"\ndiff --git cumulus/pallets/parachain-system/Cargo.toml cumulus/pallets/parachain-system/Cargo.toml\nindex cfc439..c5f4c6 100644\n--- cumulus/pallets/parachain-system/Cargo.toml\n+++ cumulus/pallets/parachain-system/Cargo.toml\n@@ -74,0 +75,5 @@ std = [\n+\t\"cumulus-test-relay-sproof-builder/std\",\n+\t\"polkadot-parachain/std\",\n+\t\"sp-inherents/std\",\n+\t\"sp-tracing/std\",\n+\t\"sp-version/std\"\ndiff --git cumulus/pallets/xcm/Cargo.toml cumulus/pallets/xcm/Cargo.toml\nindex d6b8c6..447a57 100644\n--- cumulus/pallets/xcm/Cargo.toml\n+++ cumulus/pallets/xcm/Cargo.toml\n@@ -31,0 +32 @@ std = [\n+\t\"sp-io/std\"\ndiff --git cumulus/pallets/xcmp-queue/Cargo.toml cumulus/pallets/xcmp-queue/Cargo.toml\nindex 2cd319..0b0cb0 100644\n--- cumulus/pallets/xcmp-queue/Cargo.toml\n+++ cumulus/pallets/xcmp-queue/Cargo.toml\n@@ -57,0 +58,5 @@ std = [\n+\t\"cumulus-pallet-parachain-system/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"pallet-balances/std\",\n+\t\"sp-core/std\",\n+\t\"xcm-builder/std\"\ndiff --git cumulus/parachain-template/pallets/template/Cargo.toml cumulus/parachain-template/pallets/template/Cargo.toml\nindex 9235cb..2cbfac 100644\n--- cumulus/parachain-template/pallets/template/Cargo.toml\n+++ cumulus/parachain-template/pallets/template/Cargo.toml\n@@ -39,0 +40,3 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-io/std\",\n+\t\"sp-runtime/std\"\ndiff --git cumulus/parachain-template/runtime/Cargo.toml cumulus/parachain-template/runtime/Cargo.toml\nindex c61df9..c7b97b 100644\n--- cumulus/parachain-template/runtime/Cargo.toml\n+++ cumulus/parachain-template/runtime/Cargo.toml\n@@ -120,0 +121,4 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\"\ndiff --git cumulus/parachains/common/Cargo.toml cumulus/parachains/common/Cargo.toml\nindex 5900ec..3b1120 100644\n--- cumulus/parachains/common/Cargo.toml\n+++ cumulus/parachains/common/Cargo.toml\n@@ -65,0 +66,4 @@ std = [\n+\t\"pallet-asset-tx-payment/std\",\n+\t\"sp-core/std\",\n+\t\"sp-runtime/std\",\n+\t\"xcm-builder/std\"\ndiff --git cumulus/parachains/pallets/parachain-info/Cargo.toml cumulus/parachains/pallets/parachain-info/Cargo.toml\nindex 11876b..2be2f5 100644\n--- cumulus/parachains/pallets/parachain-info/Cargo.toml\n+++ cumulus/parachains/pallets/parachain-info/Cargo.toml\n@@ -27,0 +28,2 @@ std = [\n+\t\"sp-runtime/std\",\n+\t\"sp-std/std\"\ndiff --git cumulus/parachains/pallets/ping/Cargo.toml cumulus/parachains/pallets/ping/Cargo.toml\nindex d883be..4525c7 100644\n--- cumulus/parachains/pallets/ping/Cargo.toml\n+++ cumulus/parachains/pallets/ping/Cargo.toml\n@@ -31,0 +32 @@ std = [\n+\t\"cumulus-pallet-xcm/std\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\nindex 682581..ca2ede 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n@@ -209,0 +210,8 @@ std = [\n+\t\"asset-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-weights/std\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\nindex dba374..70c5fa 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n@@ -189,0 +190,8 @@ std = [\n+\t\"asset-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-weights/std\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\nindex 1e9c49..9950a4 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n@@ -199,0 +200,8 @@ std = [\n+\t\"asset-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-io/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/assets/test-utils/Cargo.toml cumulus/parachains/runtimes/assets/test-utils/Cargo.toml\nindex 919f1b..1e8b04 100644\n--- cumulus/parachains/runtimes/assets/test-utils/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/test-utils/Cargo.toml\n@@ -75,0 +76 @@ std = [\n+\t\"sp-core/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\nindex 0dbe3e..d5f170 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n@@ -127,0 +128,7 @@ std = [\n+\t\"bridge-hub-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\nindex 9243f2..b8ff6c 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n@@ -127,0 +128,7 @@ std = [\n+\t\"bridge-hub-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\nindex 5e049d..16adef 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n@@ -163,0 +164,6 @@ std = [\n+\t\"bridge-hub-test-utils/std\",\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml\nindex 1efa80..4565b5 100644\n--- cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/test-utils/Cargo.toml\n@@ -98,0 +99,2 @@ std = [\n+\t\"pallet-collator-selection/std\",\n+\t\"pallet-xcm-benchmarks?/std\"\ndiff --git cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\nindex 3d2f6e..7bf470 100644\n--- cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n@@ -197,0 +198,7 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"sp-arithmetic/std\",\n+\t\"sp-io/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\nindex 67885d..904e01 100644\n--- cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n@@ -130,0 +131,4 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\nindex 43bf46..924b8a 100644\n--- cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n@@ -85,0 +86,4 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/starters/shell/Cargo.toml cumulus/parachains/runtimes/starters/shell/Cargo.toml\nindex d15270..7a0ae5 100644\n--- cumulus/parachains/runtimes/starters/shell/Cargo.toml\n+++ cumulus/parachains/runtimes/starters/shell/Cargo.toml\n@@ -68,0 +69 @@ std = [\n+\t\"frame-try-runtime?/std\"\ndiff --git cumulus/parachains/runtimes/test-utils/Cargo.toml cumulus/parachains/runtimes/test-utils/Cargo.toml\nindex 6fbda8..3e0388 100644\n--- cumulus/parachains/runtimes/test-utils/Cargo.toml\n+++ cumulus/parachains/runtimes/test-utils/Cargo.toml\n@@ -74,0 +75,2 @@ std = [\n+\t\"sp-core/std\",\n+\t\"sp-tracing/std\"\ndiff --git cumulus/parachains/runtimes/testing/penpal/Cargo.toml cumulus/parachains/runtimes/testing/penpal/Cargo.toml\nindex dc945a..032592 100644\n--- cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n+++ cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n@@ -125,0 +126,5 @@ std = [\n+\t\"cumulus-pallet-session-benchmarking/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"frame-try-runtime?/std\",\n+\t\"sp-storage/std\"\ndiff --git cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\nindex 9a16d3..083621 100644\n--- cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\n+++ cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\n@@ -100,0 +101,2 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"polkadot-parachain/std\"\ndiff --git cumulus/primitives/core/Cargo.toml cumulus/primitives/core/Cargo.toml\nindex 872278..6f306c 100644\n--- cumulus/primitives/core/Cargo.toml\n+++ cumulus/primitives/core/Cargo.toml\n@@ -34,0 +35 @@ std = [\n+\t\"xcm/std\"\ndiff --git cumulus/primitives/parachain-inherent/Cargo.toml cumulus/primitives/parachain-inherent/Cargo.toml\nindex ffcc0a..e3afb7 100644\n--- cumulus/primitives/parachain-inherent/Cargo.toml\n+++ cumulus/primitives/parachain-inherent/Cargo.toml\n@@ -47,0 +48,5 @@ std = [\n+\t\"cumulus-test-relay-sproof-builder?/std\",\n+\t\"sp-api?/std\",\n+\t\"sp-runtime?/std\",\n+\t\"sp-state-machine?/std\",\n+\t\"sp-storage?/std\"\ndiff --git cumulus/test/relay-sproof-builder/Cargo.toml cumulus/test/relay-sproof-builder/Cargo.toml\nindex 1f7aaf..fe7779 100644\n--- cumulus/test/relay-sproof-builder/Cargo.toml\n+++ cumulus/test/relay-sproof-builder/Cargo.toml\n@@ -30,0 +31 @@ std = [\n+\t\"polkadot-primitives/std\"\ndiff --git polkadot/parachain/test-parachains/Cargo.toml polkadot/parachain/test-parachains/Cargo.toml\nindex fdc3c7..503a14 100644\n--- polkadot/parachain/test-parachains/Cargo.toml\n+++ polkadot/parachain/test-parachains/Cargo.toml\n@@ -22 +22,5 @@ default = [ \"std\" ]\n-std = [ \"adder/std\", \"halt/std\" ]\n+std = [\n+\t\"adder/std\",\n+\t\"halt/std\", \n+\t\"sp-core/std\"\n+]\ndiff --git polkadot/parachain/test-parachains/adder/Cargo.toml polkadot/parachain/test-parachains/adder/Cargo.toml\nindex ca477e..3bda9f 100644\n--- polkadot/parachain/test-parachains/adder/Cargo.toml\n+++ polkadot/parachain/test-parachains/adder/Cargo.toml\n@@ -26 +26,5 @@ default = [ \"std\" ]\n-std = [ \"parachain/std\", \"sp-std/std\" ]\n+std = [\n+\t\"parachain/std\",\n+\t\"sp-std/std\", \n+\t\"sp-io/std\"\n+]\ndiff --git polkadot/parachain/test-parachains/undying/Cargo.toml polkadot/parachain/test-parachains/undying/Cargo.toml\nindex 192e89..2a0607 100644\n--- polkadot/parachain/test-parachains/undying/Cargo.toml\n+++ polkadot/parachain/test-parachains/undying/Cargo.toml\n@@ -27 +27,5 @@ default = [ \"std\" ]\n-std = [ \"parachain/std\", \"sp-std/std\" ]\n+std = [\n+\t\"parachain/std\",\n+\t\"sp-std/std\", \n+\t\"sp-io/std\"\n+]\ndiff --git polkadot/primitives/Cargo.toml polkadot/primitives/Cargo.toml\nindex be0531..fd55c6 100644\n--- polkadot/primitives/Cargo.toml\n+++ polkadot/primitives/Cargo.toml\n@@ -51,0 +52 @@ std = [\n+\t\"sp-keystore?/std\"\ndiff --git polkadot/runtime/common/Cargo.toml polkadot/runtime/common/Cargo.toml\nindex 72b077..0b9f01 100644\n--- polkadot/runtime/common/Cargo.toml\n+++ polkadot/runtime/common/Cargo.toml\n@@ -102,0 +103,5 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-election-provider-support/std\",\n+\t\"frame-support-test/std\",\n+\t\"pallet-babe?/std\",\n+\t\"sp-keystore/std\"\ndiff --git polkadot/runtime/kusama/Cargo.toml polkadot/runtime/kusama/Cargo.toml\nindex d04f67..252830 100644\n--- polkadot/runtime/kusama/Cargo.toml\n+++ polkadot/runtime/kusama/Cargo.toml\n@@ -217,0 +218,11 @@ std = [\n+\t\"binary-merkle-tree/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-election-provider-support-benchmarking?/std\",\n+\t\"pallet-nomination-pools-benchmarking?/std\",\n+\t\"pallet-offences-benchmarking?/std\",\n+\t\"pallet-session-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\",\n+\t\"sp-trie/std\"\ndiff --git polkadot/runtime/metrics/Cargo.toml polkadot/runtime/metrics/Cargo.toml\nindex de3114..9d88df 100644\n--- polkadot/runtime/metrics/Cargo.toml\n+++ polkadot/runtime/metrics/Cargo.toml\n@@ -24,0 +25 @@ std = [\n+\t\"frame-benchmarking?/std\"\ndiff --git polkadot/runtime/parachains/Cargo.toml polkadot/runtime/parachains/Cargo.toml\nindex f4f647..22f584 100644\n--- polkadot/runtime/parachains/Cargo.toml\n+++ polkadot/runtime/parachains/Cargo.toml\n@@ -98,0 +99,6 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-support-test/std\",\n+\t\"polkadot-parachain/std\",\n+\t\"sp-application-crypto?/std\",\n+\t\"sp-keystore?/std\",\n+\t\"sp-tracing?/std\"\ndiff --git polkadot/runtime/polkadot/Cargo.toml polkadot/runtime/polkadot/Cargo.toml\nindex 1d2ce8..d3c0e9 100644\n--- polkadot/runtime/polkadot/Cargo.toml\n+++ polkadot/runtime/polkadot/Cargo.toml\n@@ -199,0 +200,12 @@ std = [\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-election-provider-support-benchmarking?/std\",\n+\t\"pallet-nomination-pools-benchmarking?/std\",\n+\t\"pallet-offences-benchmarking?/std\",\n+\t\"pallet-session-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"runtime-parachains/std\",\n+\t\"sp-io/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\",\n+\t\"sp-trie/std\"\ndiff --git polkadot/runtime/rococo/Cargo.toml polkadot/runtime/rococo/Cargo.toml\nindex ebb7cd..2a54bf 100644\n--- polkadot/runtime/rococo/Cargo.toml\n+++ polkadot/runtime/rococo/Cargo.toml\n@@ -184,0 +185,7 @@ std = [\n+\t\"binary-merkle-tree/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\",\n+\t\"sp-trie/std\"\ndiff --git polkadot/runtime/test-runtime/Cargo.toml polkadot/runtime/test-runtime/Cargo.toml\nindex e5d04a..258920 100644\n--- polkadot/runtime/test-runtime/Cargo.toml\n+++ polkadot/runtime/test-runtime/Cargo.toml\n@@ -136,0 +137,3 @@ std = [\n+\t\"polkadot-runtime-parachains/std\",\n+\t\"sp-mmr-primitives/std\",\n+\t\"sp-trie/std\"\ndiff --git polkadot/runtime/westend/Cargo.toml polkadot/runtime/westend/Cargo.toml\nindex 40664e..f43a8b 100644\n--- polkadot/runtime/westend/Cargo.toml\n+++ polkadot/runtime/westend/Cargo.toml\n@@ -202,0 +203,10 @@ std = [\n+\t\"binary-merkle-tree/std\",\n+\t\"frame-benchmarking?/std\",\n+\t\"frame-system-benchmarking?/std\",\n+\t\"pallet-election-provider-support-benchmarking?/std\",\n+\t\"pallet-nomination-pools-benchmarking?/std\",\n+\t\"pallet-offences-benchmarking?/std\",\n+\t\"pallet-session-benchmarking?/std\",\n+\t\"pallet-xcm-benchmarks?/std\",\n+\t\"sp-storage/std\",\n+\t\"sp-tracing/std\"\ndiff --git polkadot/xcm/Cargo.toml polkadot/xcm/Cargo.toml\nindex d33b1b..2f2388 100644\n--- polkadot/xcm/Cargo.toml\n+++ polkadot/xcm/Cargo.toml\n@@ -33,0 +34 @@ std = [\n+\t\"sp-io/std\"\ndiff --git polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml\nindex f6f993..672bb4 100644\n--- polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml\n+++ polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml\n@@ -48,0 +49,8 @@ std = [\n+\t\"pallet-assets/std\",\n+\t\"pallet-balances/std\",\n+\t\"pallet-xcm/std\",\n+\t\"polkadot-primitives/std\",\n+\t\"polkadot-runtime-common/std\",\n+\t\"sp-core/std\",\n+\t\"sp-tracing/std\",\n+\t\"xcm/std\"\ndiff --git polkadot/xcm/pallet-xcm/Cargo.toml polkadot/xcm/pallet-xcm/Cargo.toml\nindex eefc3c..57e471 100644\n--- polkadot/xcm/pallet-xcm/Cargo.toml\n+++ polkadot/xcm/pallet-xcm/Cargo.toml\n@@ -50,0 +51,4 @@ std = [\n+\t\"pallet-balances/std\",\n+\t\"polkadot-parachain/std\",\n+\t\"polkadot-runtime-parachains/std\",\n+\t\"xcm-builder/std\"\ndiff --git polkadot/xcm/xcm-builder/Cargo.toml polkadot/xcm/xcm-builder/Cargo.toml\nindex 336162..2cd29a 100644\n--- polkadot/xcm/xcm-builder/Cargo.toml\n+++ polkadot/xcm/xcm-builder/Cargo.toml\n@@ -61,0 +62,7 @@ std = [\n+\t\"pallet-assets/std\",\n+\t\"pallet-balances/std\",\n+\t\"pallet-salary/std\",\n+\t\"pallet-xcm/std\",\n+\t\"primitives/std\",\n+\t\"polkadot-runtime-parachains/std\",\n+\t\"polkadot-test-runtime/std\"\ndiff --git polkadot/xcm/xcm-executor/integration-tests/Cargo.toml polkadot/xcm/xcm-executor/integration-tests/Cargo.toml\nindex ecd709..b05bfa 100644\n--- polkadot/xcm/xcm-executor/integration-tests/Cargo.toml\n+++ polkadot/xcm/xcm-executor/integration-tests/Cargo.toml\n@@ -29 +29,11 @@ default = [ \"std\" ]\n-std = [ \"frame-support/std\", \"sp-runtime/std\", \"xcm/std\" ]\n+std = [\n+\t\"frame-support/std\",\n+\t\"sp-runtime/std\",\n+\t\"xcm/std\",\n+\t\"frame-system/std\",\n+\t\"pallet-xcm/std\",\n+\t\"polkadot-test-runtime/std\",\n+\t\"sp-state-machine/std\",\n+\t\"sp-tracing/std\",\n+\t\"xcm-executor/std\"\n+]\n"
+- cmd: lint propagate-feature --feature try-runtime --left-side-feature-missing=ignore --workspace --fix
+  stdout: |
+    crate 'asset-hub-kusama-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'asset-hub-polkadot-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'asset-hub-westend-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'bridge-hub-kusama-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'bridge-hub-polkadot-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'bridge-hub-rococo-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'collectives-polkadot-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'contracts-rococo-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'cumulus-pallet-aura-ext'
+      feature 'try-runtime'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          frame-system
+          pallet-aura
+          pallet-timestamp
+          sp-runtime
+    crate 'cumulus-pallet-dmp-queue'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'cumulus-pallet-parachain-system'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'cumulus-pallet-solo-to-para'
+      feature 'try-runtime'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          frame-system
+          pallet-sudo
+          sp-runtime
+    crate 'cumulus-pallet-xcm'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'cumulus-pallet-xcmp-queue'
+      feature 'try-runtime'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          frame-system
+          pallet-balances
+          polkadot-runtime-common
+          sp-runtime
+    crate 'glutton-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          cumulus-pallet-xcm
+          frame-support
+          frame-system
+          parachain-info
+          sp-runtime
+    crate 'kusama-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-try-runtime
+          runtime-parachains (renamed from polkadot-runtime-parachains)
+          sp-runtime
+    crate 'pallet-bridge-grandpa'
+      feature 'try-runtime'
+        must propagate to:
+          sp-runtime
+    crate 'pallet-bridge-messages'
+      feature 'try-runtime'
+        must propagate to:
+          pallet-balances
+          sp-runtime
+    crate 'pallet-bridge-parachains'
+      feature 'try-runtime'
+        must propagate to:
+          pallet-bridge-grandpa
+          sp-runtime
+    crate 'pallet-bridge-relayers'
+      feature 'try-runtime'
+        must propagate to:
+          pallet-balances
+          pallet-bridge-messages
+          sp-runtime
+    crate 'pallet-collator-selection'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-aura
+          pallet-authorship
+          pallet-balances
+          pallet-session
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-parachain-template'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-xcm'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          polkadot-runtime-parachains
+          sp-runtime
+    crate 'pallet-xcm-bridge-hub-router'
+      feature 'try-runtime'
+        must propagate to:
+          sp-runtime
+    crate 'parachain-info'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'parachain-template-node'
+      feature 'try-runtime'
+        must propagate to:
+          polkadot-cli
+          sp-runtime
+    crate 'parachain-template-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'penpal-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          polkadot-runtime-common
+          sp-runtime
+    crate 'polkadot-parachain-bin'
+      feature 'try-runtime'
+        must propagate to:
+          bridge-hub-kusama-runtime
+          bridge-hub-polkadot-runtime
+          bridge-hub-rococo-runtime
+          collectives-polkadot-runtime
+          contracts-rococo-runtime
+          glutton-runtime
+          penpal-runtime
+          polkadot-cli
+          polkadot-service
+          sp-runtime
+    crate 'polkadot-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-try-runtime
+          runtime-parachains (renamed from polkadot-runtime-parachains)
+          sp-runtime
+    crate 'polkadot-runtime-common'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-support-test
+          frame-system
+          pallet-babe
+          pallet-election-provider-multi-phase
+          sp-runtime
+    crate 'polkadot-runtime-parachains'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support-test
+          frame-system
+          sp-runtime
+    crate 'polkadot-service'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-babe
+          pallet-im-online
+          pallet-staking
+          pallet-transaction-payment
+          polkadot-runtime-common
+          polkadot-runtime-parachains
+          sp-runtime
+    crate 'rococo-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          frame-try-runtime
+          sp-runtime
+    crate 'shell-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          cumulus-pallet-xcm
+          frame-support
+          frame-system
+          parachain-info
+          sp-runtime
+    crate 'westend-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-try-runtime
+          runtime-parachains (renamed from polkadot-runtime-parachains)
+          sp-runtime
+    Found 135 issues and fixed 135.
+  diff: "diff --git cumulus/bridges/modules/grandpa/Cargo.toml cumulus/bridges/modules/grandpa/Cargo.toml\nindex 3e25b5..58823f 100644\n--- cumulus/bridges/modules/grandpa/Cargo.toml\n+++ cumulus/bridges/modules/grandpa/Cargo.toml\n@@ -60 +60,5 @@ runtime-benchmarks = [\n-try-runtime = [ \"frame-support/try-runtime\", \"frame-system/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\", \n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/bridges/modules/messages/Cargo.toml cumulus/bridges/modules/messages/Cargo.toml\nindex 8108b5..2cc35d 100644\n--- cumulus/bridges/modules/messages/Cargo.toml\n+++ cumulus/bridges/modules/messages/Cargo.toml\n@@ -51 +51,6 @@ runtime-benchmarks = [ \"frame-benchmarking/runtime-benchmarks\" ]\n-try-runtime = [ \"frame-support/try-runtime\", \"frame-system/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-balances/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/bridges/modules/parachains/Cargo.toml cumulus/bridges/modules/parachains/Cargo.toml\nindex d7384c..88eb9d 100644\n--- cumulus/bridges/modules/parachains/Cargo.toml\n+++ cumulus/bridges/modules/parachains/Cargo.toml\n@@ -55 +55,6 @@ runtime-benchmarks = [ \"frame-benchmarking/runtime-benchmarks\" ]\n-try-runtime = [ \"frame-support/try-runtime\", \"frame-system/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-bridge-grandpa/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/bridges/modules/relayers/Cargo.toml cumulus/bridges/modules/relayers/Cargo.toml\nindex 8a5a4e..4ed273 100644\n--- cumulus/bridges/modules/relayers/Cargo.toml\n+++ cumulus/bridges/modules/relayers/Cargo.toml\n@@ -54 +54,7 @@ runtime-benchmarks = [ \"frame-benchmarking/runtime-benchmarks\" ]\n-try-runtime = [ \"frame-support/try-runtime\", \"frame-system/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-balances/try-runtime\",\n+\t\"pallet-bridge-messages/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\nindex 7f57c5..316c3c 100644\n--- cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\n+++ cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\n@@ -56 +56,5 @@ runtime-benchmarks = [\n-try-runtime = [ \"frame-support/try-runtime\", \"frame-system/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\", \n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/pallets/aura-ext/Cargo.toml cumulus/pallets/aura-ext/Cargo.toml\nindex b29bbe..175b5b 100644\n--- cumulus/pallets/aura-ext/Cargo.toml\n+++ cumulus/pallets/aura-ext/Cargo.toml\n@@ -44 +44,8 @@ std = [\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"cumulus-pallet-parachain-system/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-aura/try-runtime\",\n+\t\"pallet-timestamp/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/pallets/collator-selection/Cargo.toml cumulus/pallets/collator-selection/Cargo.toml\nindex cce7e3..a0d4be 100644\n--- cumulus/pallets/collator-selection/Cargo.toml\n+++ cumulus/pallets/collator-selection/Cargo.toml\n@@ -63 +63,10 @@ std = [\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-aura/try-runtime\",\n+\t\"pallet-authorship/try-runtime\",\n+\t\"pallet-balances/try-runtime\",\n+\t\"pallet-session/try-runtime\",\n+\t\"pallet-timestamp/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/pallets/dmp-queue/Cargo.toml cumulus/pallets/dmp-queue/Cargo.toml\nindex 377738..4110c9 100644\n--- cumulus/pallets/dmp-queue/Cargo.toml\n+++ cumulus/pallets/dmp-queue/Cargo.toml\n@@ -43 +43,5 @@ std = [\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/pallets/parachain-system/Cargo.toml cumulus/pallets/parachain-system/Cargo.toml\nindex cfc439..f6b3ae 100644\n--- cumulus/pallets/parachain-system/Cargo.toml\n+++ cumulus/pallets/parachain-system/Cargo.toml\n@@ -79 +79,5 @@ runtime-benchmarks = [ \"sp-runtime/runtime-benchmarks\" ]\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/pallets/solo-to-para/Cargo.toml cumulus/pallets/solo-to-para/Cargo.toml\nindex 94e0be..e94d9e 100644\n--- cumulus/pallets/solo-to-para/Cargo.toml\n+++ cumulus/pallets/solo-to-para/Cargo.toml\n@@ -38 +38,7 @@ std = [\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"cumulus-pallet-parachain-system/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-sudo/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/pallets/xcm/Cargo.toml cumulus/pallets/xcm/Cargo.toml\nindex d6b8c6..bddfdd 100644\n--- cumulus/pallets/xcm/Cargo.toml\n+++ cumulus/pallets/xcm/Cargo.toml\n@@ -33 +33,5 @@ std = [\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/pallets/xcmp-queue/Cargo.toml cumulus/pallets/xcmp-queue/Cargo.toml\nindex 2cd319..e4b9f8 100644\n--- cumulus/pallets/xcmp-queue/Cargo.toml\n+++ cumulus/pallets/xcmp-queue/Cargo.toml\n@@ -66 +66,8 @@ runtime-benchmarks = [\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"cumulus-pallet-parachain-system/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-balances/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/parachain-template/node/Cargo.toml cumulus/parachain-template/node/Cargo.toml\nindex f110e9..d0cac2 100644\n--- cumulus/parachain-template/node/Cargo.toml\n+++ cumulus/parachain-template/node/Cargo.toml\n@@ -81 +81,5 @@ runtime-benchmarks = [\n-try-runtime = [ \"parachain-template-runtime/try-runtime\" ]\n+try-runtime = [\n+\t\"parachain-template-runtime/try-runtime\",\n+\t\"polkadot-cli/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/parachain-template/pallets/template/Cargo.toml cumulus/parachain-template/pallets/template/Cargo.toml\nindex 9235cb..a89467 100644\n--- cumulus/parachain-template/pallets/template/Cargo.toml\n+++ cumulus/parachain-template/pallets/template/Cargo.toml\n@@ -41 +41,5 @@ std = [\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/parachain-template/runtime/Cargo.toml cumulus/parachain-template/runtime/Cargo.toml\nindex c61df9..96675a 100644\n--- cumulus/parachain-template/runtime/Cargo.toml\n+++ cumulus/parachain-template/runtime/Cargo.toml\n@@ -161,0 +162,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/pallets/parachain-info/Cargo.toml cumulus/parachains/pallets/parachain-info/Cargo.toml\nindex 11876b..7c45e3 100644\n--- cumulus/parachains/pallets/parachain-info/Cargo.toml\n+++ cumulus/parachains/pallets/parachain-info/Cargo.toml\n@@ -29 +29,5 @@ std = [\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\nindex 682581..67cbed 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n@@ -151,0 +152,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\nindex dba374..5b77dd 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n@@ -134,0 +135,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\nindex 1e9c49..46fd24 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n@@ -142,0 +143,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\nindex 0dbe3e..45b9e4 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n@@ -168,0 +169,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\nindex 9243f2..93c13d 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n@@ -168,0 +169,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\nindex 5e049d..59370d 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n@@ -213,0 +214,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\nindex 3d2f6e..1bd5df 100644\n--- cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n@@ -140,0 +141,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\nindex 67885d..e5d1b1 100644\n--- cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n@@ -175,0 +176,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\nindex 43bf46..44124a 100644\n--- cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n@@ -91,0 +92,6 @@ try-runtime = [\n+\t\"cumulus-pallet-parachain-system/try-runtime\",\n+\t\"cumulus-pallet-xcm/try-runtime\",\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"parachain-info/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/parachains/runtimes/starters/shell/Cargo.toml cumulus/parachains/runtimes/starters/shell/Cargo.toml\nindex d15270..31510c 100644\n--- cumulus/parachains/runtimes/starters/shell/Cargo.toml\n+++ cumulus/parachains/runtimes/starters/shell/Cargo.toml\n@@ -70 +70,10 @@ std = [\n-try-runtime = [ \"frame-executive/try-runtime\", \"frame-try-runtime/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-executive/try-runtime\",\n+\t\"frame-try-runtime/try-runtime\",\n+\t\"cumulus-pallet-parachain-system/try-runtime\",\n+\t\"cumulus-pallet-xcm/try-runtime\",\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"parachain-info/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\ndiff --git cumulus/parachains/runtimes/testing/penpal/Cargo.toml cumulus/parachains/runtimes/testing/penpal/Cargo.toml\nindex dc945a..6120ec 100644\n--- cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n+++ cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n@@ -166,0 +167,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git cumulus/polkadot-parachain/Cargo.toml cumulus/polkadot-parachain/Cargo.toml\nindex ad7c6e..cdc755 100644\n--- cumulus/polkadot-parachain/Cargo.toml\n+++ cumulus/polkadot-parachain/Cargo.toml\n@@ -125,0 +126,10 @@ try-runtime = [\n+\t\"bridge-hub-kusama-runtime/try-runtime\",\n+\t\"bridge-hub-polkadot-runtime/try-runtime\",\n+\t\"bridge-hub-rococo-runtime/try-runtime\",\n+\t\"collectives-polkadot-runtime/try-runtime\",\n+\t\"contracts-rococo-runtime/try-runtime\",\n+\t\"glutton-runtime/try-runtime\",\n+\t\"penpal-runtime/try-runtime\",\n+\t\"polkadot-cli/try-runtime\",\n+\t\"polkadot-service/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git polkadot/node/service/Cargo.toml polkadot/node/service/Cargo.toml\nindex f58f4a..c4fb36 100644\n--- polkadot/node/service/Cargo.toml\n+++ polkadot/node/service/Cargo.toml\n@@ -205,0 +206,9 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-babe/try-runtime\",\n+\t\"pallet-im-online/try-runtime\",\n+\t\"pallet-staking/try-runtime\",\n+\t\"pallet-transaction-payment/try-runtime\",\n+\t\"polkadot-runtime-common/try-runtime\",\n+\t\"polkadot-runtime-parachains/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git polkadot/runtime/common/Cargo.toml polkadot/runtime/common/Cargo.toml\nindex 72b077..14db61 100644\n--- polkadot/runtime/common/Cargo.toml\n+++ polkadot/runtime/common/Cargo.toml\n@@ -124,0 +125,7 @@ try-runtime = [\n+\t\"frame-election-provider-support/try-runtime\",\n+\t\"frame-support/try-runtime\",\n+\t\"frame-support-test/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-babe?/try-runtime\",\n+\t\"pallet-election-provider-multi-phase/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git polkadot/runtime/kusama/Cargo.toml polkadot/runtime/kusama/Cargo.toml\nindex d04f67..fb5f47 100644\n--- polkadot/runtime/kusama/Cargo.toml\n+++ polkadot/runtime/kusama/Cargo.toml\n@@ -318,0 +319,5 @@ try-runtime = [\n+\t\"frame-election-provider-support/try-runtime\",\n+\t\"frame-support/try-runtime\",\n+\t\"frame-try-runtime?/try-runtime\",\n+\t\"runtime-parachains/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git polkadot/runtime/parachains/Cargo.toml polkadot/runtime/parachains/Cargo.toml\nindex f4f647..eba236 100644\n--- polkadot/runtime/parachains/Cargo.toml\n+++ polkadot/runtime/parachains/Cargo.toml\n@@ -124,0 +125,3 @@ try-runtime = [\n+\t\"frame-support-test/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git polkadot/runtime/polkadot/Cargo.toml polkadot/runtime/polkadot/Cargo.toml\nindex 1d2ce8..c591b6 100644\n--- polkadot/runtime/polkadot/Cargo.toml\n+++ polkadot/runtime/polkadot/Cargo.toml\n@@ -289,0 +290,5 @@ try-runtime = [\n+\t\"frame-election-provider-support/try-runtime\",\n+\t\"frame-support/try-runtime\",\n+\t\"frame-try-runtime?/try-runtime\",\n+\t\"runtime-parachains/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git polkadot/runtime/rococo/Cargo.toml polkadot/runtime/rococo/Cargo.toml\nindex ebb7cd..d9509a 100644\n--- polkadot/runtime/rococo/Cargo.toml\n+++ polkadot/runtime/rococo/Cargo.toml\n@@ -268,0 +269,3 @@ try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-try-runtime?/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git polkadot/runtime/westend/Cargo.toml polkadot/runtime/westend/Cargo.toml\nindex 40664e..dfb369 100644\n--- polkadot/runtime/westend/Cargo.toml\n+++ polkadot/runtime/westend/Cargo.toml\n@@ -289,0 +290,5 @@ try-runtime = [\n+\t\"frame-election-provider-support/try-runtime\",\n+\t\"frame-support/try-runtime\",\n+\t\"frame-try-runtime?/try-runtime\",\n+\t\"runtime-parachains/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\ndiff --git polkadot/xcm/pallet-xcm/Cargo.toml polkadot/xcm/pallet-xcm/Cargo.toml\nindex eefc3c..de9bad 100644\n--- polkadot/xcm/pallet-xcm/Cargo.toml\n+++ polkadot/xcm/pallet-xcm/Cargo.toml\n@@ -58 +58,7 @@ runtime-benchmarks = [\n-try-runtime = [ \"frame-support/try-runtime\" ]\n+try-runtime = [\n+\t\"frame-support/try-runtime\",\n+\t\"frame-system/try-runtime\",\n+\t\"pallet-balances/try-runtime\",\n+\t\"polkadot-runtime-parachains/try-runtime\",\n+\t\"sp-runtime/try-runtime\"\n+]\n"
+- cmd: lint propagate-feature --feature runtime-benchmarks --left-side-feature-missing=ignore --workspace --fix
+  stdout: |
+    crate 'asset-hub-kusama-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-parachain
+          polkadot-runtime-common
+          xcm-executor
+    crate 'asset-hub-polkadot-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-asset-tx-payment
+          polkadot-parachain
+          polkadot-runtime-common
+          xcm-executor
+    crate 'asset-hub-westend-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-parachain
+          polkadot-runtime-common
+          xcm-executor
+    crate 'assets-common'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-asset-conversion
+          pallet-asset-tx-payment
+          sp-runtime
+          xcm-executor
+    crate 'bridge-hub-kusama-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-parachain
+          polkadot-runtime-common
+          xcm-executor
+    crate 'bridge-hub-polkadot-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-parachain
+          polkadot-runtime-common
+          xcm-executor
+    crate 'bridge-hub-rococo-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-parachain
+          polkadot-runtime-common
+          xcm-executor
+    crate 'bridge-runtime-common'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-utility
+          sp-runtime
+    crate 'collectives-polkadot-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-parachain
+          polkadot-runtime-common
+          xcm-executor
+    crate 'contracts-rococo-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          cumulus-pallet-xcmp-queue
+          polkadot-parachain
+          polkadot-runtime-common
+          xcm-executor
+    crate 'cumulus-pallet-parachain-system'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          polkadot-parachain
+    crate 'cumulus-pallet-session-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          sp-runtime
+    crate 'cumulus-pallet-xcmp-queue'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          pallet-balances
+          polkadot-runtime-common
+          sp-runtime
+          xcm-executor
+    crate 'cumulus-test-service'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          frame-system
+          pallet-im-online
+          pallet-timestamp
+          polkadot-cli
+          polkadot-primitives
+          polkadot-service
+          rococo-parachain-runtime
+          sc-service
+          sp-runtime
+    crate 'glutton-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-sudo
+          sp-runtime
+          xcm-executor
+    crate 'integration-tests-common'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          asset-hub-kusama-runtime
+          asset-hub-polkadot-runtime
+          asset-hub-westend-runtime
+          bridge-hub-kusama-runtime
+          bridge-hub-polkadot-runtime
+          bridge-hub-rococo-runtime
+          bridge-runtime-common
+          collectives-polkadot-runtime
+          cumulus-pallet-parachain-system
+          cumulus-pallet-xcmp-queue
+          frame-support
+          frame-system
+          pallet-assets
+          pallet-balances
+          pallet-bridge-messages
+          pallet-im-online
+          pallet-message-queue
+          pallet-staking
+          pallet-xcm
+          penpal-runtime
+          polkadot-parachain
+          polkadot-primitives
+          polkadot-runtime-parachains
+          polkadot-service
+          rococo-runtime
+          sp-runtime
+          xcm-executor
+    crate 'kusama-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-mmr
+          pallet-offences
+          pallet-state-trie-migration
+          primitives (renamed from polkadot-primitives)
+          sp-staking
+          xcm-executor (renamed from xcm-executor)
+    crate 'pallet-bridge-grandpa'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-bridge-messages'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-bridge-parachains'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-bridge-grandpa
+          sp-runtime
+    crate 'pallet-bridge-relayers'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-bridge-messages
+          sp-runtime
+    crate 'pallet-collator-selection'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-timestamp
+          sp-runtime
+          sp-staking
+    crate 'pallet-parachain-template'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-xcm'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          polkadot-parachain
+          polkadot-runtime-parachains
+          sp-runtime
+          xcm-executor
+    crate 'pallet-xcm-benchmarks'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-assets
+          pallet-balances
+          polkadot-primitives
+          polkadot-runtime-common
+          sp-runtime
+    crate 'pallet-xcm-bridge-hub-router'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'parachain-template-node'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-benchmarking-cli
+          polkadot-primitives
+          sc-service
+          sp-runtime
+    crate 'parachain-template-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-parachain
+          polkadot-runtime-common
+          xcm-executor
+    crate 'penpal-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          pallet-asset-tx-payment
+          polkadot-parachain
+          polkadot-primitives
+          polkadot-runtime-common
+          xcm-executor
+    crate 'polkadot-cli'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking-cli
+          sc-service
+    crate 'polkadot-node-metrics'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          primitives (renamed from polkadot-primitives)
+          polkadot-test-service
+          sc-service
+    crate 'polkadot-parachain'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          sp-runtime
+    crate 'polkadot-parachain-bin'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-benchmarking-cli
+          glutton-runtime
+          polkadot-cli
+          polkadot-primitives
+          sc-service
+          sp-runtime
+    crate 'polkadot-performance-test'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-primitives
+    crate 'polkadot-primitives'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-parachain
+          runtime_primitives (renamed from sp-runtime)
+          sp-staking
+    crate 'polkadot-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-offences
+          primitives (renamed from polkadot-primitives)
+          sp-staking
+          xcm-executor (renamed from xcm-executor)
+    crate 'polkadot-runtime-common'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          pallet-balances
+          pallet-election-provider-multi-phase
+          pallet-staking
+          pallet-timestamp
+          pallet-treasury
+          pallet-vesting
+          primitives (renamed from polkadot-primitives)
+          sp-runtime
+          sp-staking
+    crate 'polkadot-runtime-parachains'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          polkadot-parachain
+          sp-runtime
+          sp-staking
+          xcm-executor (renamed from xcm-executor)
+    crate 'polkadot-service'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-benchmarking-cli
+          frame-support
+          frame-system
+          pallet-babe
+          pallet-im-online
+          pallet-staking
+          polkadot-parachain
+          polkadot-primitives
+          polkadot-runtime-common
+          polkadot-runtime-parachains
+          polkadot-test-client
+          sc-client-db
+          sp-runtime
+    crate 'polkadot-test-client'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          polkadot-primitives
+          polkadot-test-service
+          sc-service
+          sp-runtime
+    crate 'polkadot-test-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-babe
+          pallet-balances
+          pallet-grandpa
+          pallet-indices
+          pallet-offences
+          pallet-staking
+          pallet-sudo
+          pallet-timestamp
+          pallet-vesting
+          polkadot-parachain
+          primitives (renamed from polkadot-primitives)
+          runtime-common (renamed from polkadot-runtime-common)
+          polkadot-runtime-parachains
+          sp-runtime
+          sp-staking
+          xcm-executor
+    crate 'polkadot-test-service'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-staking
+          polkadot-parachain
+          polkadot-primitives
+          polkadot-runtime-common
+          polkadot-runtime-parachains
+          sc-service
+          sp-runtime
+    crate 'rococo-parachain-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          cumulus-pallet-parachain-system
+          cumulus-pallet-xcmp-queue
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-sudo
+          pallet-timestamp
+          polkadot-parachain
+          sp-runtime
+          xcm-executor
+    crate 'rococo-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-mmr
+          pallet-offences
+          pallet-state-trie-migration
+          polkadot-parachain
+          primitives (renamed from polkadot-primitives)
+          sp-staking
+          xcm-executor (renamed from xcm-executor)
+    crate 'westend-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-mmr
+          pallet-nomination-pools
+          pallet-offences
+          pallet-state-trie-migration
+          polkadot-parachain
+          primitives (renamed from polkadot-primitives)
+          sp-staking
+          xcm-executor (renamed from xcm-executor)
+    crate 'xcm-builder'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-salary
+          pallet-xcm
+          polkadot-parachain
+          primitives (renamed from polkadot-primitives)
+          polkadot-runtime-parachains
+          polkadot-test-runtime
+          sp-runtime
+    crate 'xcm-executor'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          sp-runtime
+    crate 'xcm-simulator-example'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          sp-runtime
+    crate 'xcm-simulator-fuzzer'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-system
+          pallet-balances
+          polkadot-parachain
+          polkadot-runtime-parachains
+          sp-runtime
+          xcm-executor
+    Found 265 issues and fixed 265.
+  diff: "diff --git cumulus/bridges/bin/runtime-common/Cargo.toml cumulus/bridges/bin/runtime-common/Cargo.toml\nindex ee1334..2d07fd 100644\n--- cumulus/bridges/bin/runtime-common/Cargo.toml\n+++ cumulus/bridges/bin/runtime-common/Cargo.toml\n@@ -86,0 +87,5 @@ runtime-benchmarks = [\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"pallet-utility/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git cumulus/bridges/modules/grandpa/Cargo.toml cumulus/bridges/modules/grandpa/Cargo.toml\nindex 3e25b5..315db8 100644\n--- cumulus/bridges/modules/grandpa/Cargo.toml\n+++ cumulus/bridges/modules/grandpa/Cargo.toml\n@@ -58,0 +59,3 @@ runtime-benchmarks = [\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git cumulus/bridges/modules/messages/Cargo.toml cumulus/bridges/modules/messages/Cargo.toml\nindex 8108b5..010e8b 100644\n--- cumulus/bridges/modules/messages/Cargo.toml\n+++ cumulus/bridges/modules/messages/Cargo.toml\n@@ -50 +50,7 @@ std = [\n-runtime-benchmarks = [ \"frame-benchmarking/runtime-benchmarks\" ]\n+runtime-benchmarks = [\n+\t\"frame-benchmarking/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\n+]\ndiff --git cumulus/bridges/modules/parachains/Cargo.toml cumulus/bridges/modules/parachains/Cargo.toml\nindex d7384c..92ff6e 100644\n--- cumulus/bridges/modules/parachains/Cargo.toml\n+++ cumulus/bridges/modules/parachains/Cargo.toml\n@@ -54 +54,7 @@ std = [\n-runtime-benchmarks = [ \"frame-benchmarking/runtime-benchmarks\" ]\n+runtime-benchmarks = [\n+\t\"frame-benchmarking/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-bridge-grandpa/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\n+]\ndiff --git cumulus/bridges/modules/relayers/Cargo.toml cumulus/bridges/modules/relayers/Cargo.toml\nindex 8a5a4e..ace4b1 100644\n--- cumulus/bridges/modules/relayers/Cargo.toml\n+++ cumulus/bridges/modules/relayers/Cargo.toml\n@@ -53 +53,8 @@ std = [\n-runtime-benchmarks = [ \"frame-benchmarking/runtime-benchmarks\" ]\n+runtime-benchmarks = [\n+\t\"frame-benchmarking/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"pallet-bridge-messages/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\n+]\ndiff --git cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\nindex 7f57c5..c5f0bf 100644\n--- cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\n+++ cumulus/bridges/modules/xcm-bridge-hub-router/Cargo.toml\n@@ -54,0 +55,3 @@ runtime-benchmarks = [\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git cumulus/pallets/collator-selection/Cargo.toml cumulus/pallets/collator-selection/Cargo.toml\nindex cce7e3..2ee055 100644\n--- cumulus/pallets/collator-selection/Cargo.toml\n+++ cumulus/pallets/collator-selection/Cargo.toml\n@@ -46,0 +47,4 @@ runtime-benchmarks = [\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"pallet-timestamp/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"sp-staking/runtime-benchmarks\"\ndiff --git cumulus/pallets/parachain-system/Cargo.toml cumulus/pallets/parachain-system/Cargo.toml\nindex cfc439..84b66b 100644\n--- cumulus/pallets/parachain-system/Cargo.toml\n+++ cumulus/pallets/parachain-system/Cargo.toml\n@@ -77 +77,6 @@ std = [\n-runtime-benchmarks = [ \"sp-runtime/runtime-benchmarks\" ]\n+runtime-benchmarks = [\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\"\n+]\ndiff --git cumulus/pallets/session-benchmarking/Cargo.toml cumulus/pallets/session-benchmarking/Cargo.toml\nindex 901ddb..0b507e 100644\n--- cumulus/pallets/session-benchmarking/Cargo.toml\n+++ cumulus/pallets/session-benchmarking/Cargo.toml\n@@ -29,0 +30 @@ runtime-benchmarks = [\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git cumulus/pallets/xcmp-queue/Cargo.toml cumulus/pallets/xcmp-queue/Cargo.toml\nindex 2cd319..b5be26 100644\n--- cumulus/pallets/xcmp-queue/Cargo.toml\n+++ cumulus/pallets/xcmp-queue/Cargo.toml\n@@ -64,0 +65,5 @@ runtime-benchmarks = [\n+\t\"cumulus-pallet-parachain-system/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachain-template/node/Cargo.toml cumulus/parachain-template/node/Cargo.toml\nindex f110e9..806125 100644\n--- cumulus/parachain-template/node/Cargo.toml\n+++ cumulus/parachain-template/node/Cargo.toml\n@@ -79,0 +80,5 @@ runtime-benchmarks = [\n+\t\"frame-benchmarking/runtime-benchmarks\",\n+\t\"frame-benchmarking-cli/runtime-benchmarks\",\n+\t\"polkadot-primitives/runtime-benchmarks\",\n+\t\"sc-service/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git cumulus/parachain-template/pallets/template/Cargo.toml cumulus/parachain-template/pallets/template/Cargo.toml\nindex 9235cb..f5802f 100644\n--- cumulus/parachain-template/pallets/template/Cargo.toml\n+++ cumulus/parachain-template/pallets/template/Cargo.toml\n@@ -33 +33,6 @@ default = [ \"std\" ]\n-runtime-benchmarks = [ \"frame-benchmarking/runtime-benchmarks\" ]\n+runtime-benchmarks = [\n+\t\"frame-benchmarking/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\n+]\ndiff --git cumulus/parachain-template/runtime/Cargo.toml cumulus/parachain-template/runtime/Cargo.toml\nindex c61df9..2c835a 100644\n--- cumulus/parachain-template/runtime/Cargo.toml\n+++ cumulus/parachain-template/runtime/Cargo.toml\n@@ -139,0 +140,3 @@ runtime-benchmarks = [\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/integration-tests/emulated/common/Cargo.toml cumulus/parachains/integration-tests/emulated/common/Cargo.toml\nindex 012237..f71adb 100644\n--- cumulus/parachains/integration-tests/emulated/common/Cargo.toml\n+++ cumulus/parachains/integration-tests/emulated/common/Cargo.toml\n@@ -73,0 +74,27 @@ runtime-benchmarks = [\n+\t\"asset-hub-kusama-runtime/runtime-benchmarks\",\n+\t\"asset-hub-polkadot-runtime/runtime-benchmarks\",\n+\t\"asset-hub-westend-runtime/runtime-benchmarks\",\n+\t\"bridge-hub-kusama-runtime/runtime-benchmarks\",\n+\t\"bridge-hub-polkadot-runtime/runtime-benchmarks\",\n+\t\"bridge-hub-rococo-runtime/runtime-benchmarks\",\n+\t\"bridge-runtime-common/runtime-benchmarks\",\n+\t\"collectives-polkadot-runtime/runtime-benchmarks\",\n+\t\"cumulus-pallet-parachain-system/runtime-benchmarks\",\n+\t\"cumulus-pallet-xcmp-queue/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-assets/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"pallet-bridge-messages/runtime-benchmarks\",\n+\t\"pallet-im-online/runtime-benchmarks\",\n+\t\"pallet-message-queue/runtime-benchmarks\",\n+\t\"pallet-staking/runtime-benchmarks\",\n+\t\"pallet-xcm/runtime-benchmarks\",\n+\t\"penpal-runtime/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-primitives/runtime-benchmarks\",\n+\t\"polkadot-runtime-parachains/runtime-benchmarks\",\n+\t\"polkadot-service/runtime-benchmarks\",\n+\t\"rococo-runtime/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\nindex 682581..fd8a1a 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-kusama/Cargo.toml\n@@ -122,0 +123,3 @@ runtime-benchmarks = [\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\nindex dba374..24c767 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-polkadot/Cargo.toml\n@@ -108,0 +109,4 @@ runtime-benchmarks = [\n+\t\"pallet-asset-tx-payment/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\nindex 1e9c49..c1f042 100644\n--- cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/asset-hub-westend/Cargo.toml\n@@ -114,0 +115,3 @@ runtime-benchmarks = [\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/assets/common/Cargo.toml cumulus/parachains/runtimes/assets/common/Cargo.toml\nindex dc4f62..c6be65 100644\n--- cumulus/parachains/runtimes/assets/common/Cargo.toml\n+++ cumulus/parachains/runtimes/assets/common/Cargo.toml\n@@ -57,0 +58,4 @@ runtime-benchmarks = [\n+\t\"pallet-asset-conversion/runtime-benchmarks\",\n+\t\"pallet-asset-tx-payment/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\nindex 0dbe3e..2e5c49 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml\n@@ -146,0 +147,3 @@ runtime-benchmarks = [\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\nindex 9243f2..a33c5f 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml\n@@ -146,0 +147,3 @@ runtime-benchmarks = [\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\nindex 5e049d..b1da5f 100644\n--- cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml\n@@ -187,0 +188,3 @@ runtime-benchmarks = [\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\nindex 3d2f6e..908d22 100644\n--- cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n+++ cumulus/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml\n@@ -110,0 +111,3 @@ runtime-benchmarks = [\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\nindex 67885d..2caea3 100644\n--- cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n+++ cumulus/parachains/runtimes/contracts/contracts-rococo/Cargo.toml\n@@ -150,0 +151,4 @@ runtime-benchmarks = [\n+\t\"cumulus-pallet-xcmp-queue/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\nindex 43bf46..c86559 100644\n--- cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n+++ cumulus/parachains/runtimes/glutton/glutton-kusama/Cargo.toml\n@@ -57,0 +58,3 @@ runtime-benchmarks = [\n+\t\"pallet-sudo?/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/testing/penpal/Cargo.toml cumulus/parachains/runtimes/testing/penpal/Cargo.toml\nindex dc945a..77085b 100644\n--- cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n+++ cumulus/parachains/runtimes/testing/penpal/Cargo.toml\n@@ -143,0 +144,6 @@ runtime-benchmarks = [\n+\t\"cumulus-pallet-parachain-system/runtime-benchmarks\",\n+\t\"pallet-asset-tx-payment/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-primitives/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\nindex 9a16d3..1fd1d7 100644\n--- cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\n+++ cumulus/parachains/runtimes/testing/rococo-parachain/Cargo.toml\n@@ -106,0 +107,10 @@ runtime-benchmarks = [\n+\t\"cumulus-pallet-parachain-system/runtime-benchmarks\",\n+\t\"cumulus-pallet-xcmp-queue/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"pallet-sudo/runtime-benchmarks\",\n+\t\"pallet-timestamp/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git cumulus/polkadot-parachain/Cargo.toml cumulus/polkadot-parachain/Cargo.toml\nindex ad7c6e..d9ba75 100644\n--- cumulus/polkadot-parachain/Cargo.toml\n+++ cumulus/polkadot-parachain/Cargo.toml\n@@ -119,0 +120,7 @@ runtime-benchmarks = [\n+\t\"frame-benchmarking/runtime-benchmarks\",\n+\t\"frame-benchmarking-cli/runtime-benchmarks\",\n+\t\"glutton-runtime/runtime-benchmarks\",\n+\t\"polkadot-cli/runtime-benchmarks\",\n+\t\"polkadot-primitives/runtime-benchmarks\",\n+\t\"sc-service/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git cumulus/test/service/Cargo.toml cumulus/test/service/Cargo.toml\nindex 70d6e9..f925ec 100644\n--- cumulus/test/service/Cargo.toml\n+++ cumulus/test/service/Cargo.toml\n@@ -99 +99,13 @@ substrate-test-utils = { path = \"../../../substrate/test-utils\" }\n-runtime-benchmarks = [ \"polkadot-test-service/runtime-benchmarks\" ]\n+runtime-benchmarks = [\n+\t\"polkadot-test-service/runtime-benchmarks\",\n+\t\"cumulus-pallet-parachain-system/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-im-online/runtime-benchmarks\",\n+\t\"pallet-timestamp/runtime-benchmarks\",\n+\t\"polkadot-cli/runtime-benchmarks\",\n+\t\"polkadot-primitives/runtime-benchmarks\",\n+\t\"polkadot-service/runtime-benchmarks\",\n+\t\"rococo-parachain-runtime/runtime-benchmarks\",\n+\t\"sc-service/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\n+]\ndiff --git polkadot/cli/Cargo.toml polkadot/cli/Cargo.toml\nindex d6db97..63cbdb 100644\n--- polkadot/cli/Cargo.toml\n+++ polkadot/cli/Cargo.toml\n@@ -60,0 +61,2 @@ runtime-benchmarks = [\n+\t\"frame-benchmarking-cli?/runtime-benchmarks\",\n+\t\"sc-service?/runtime-benchmarks\"\ndiff --git polkadot/node/metrics/Cargo.toml polkadot/node/metrics/Cargo.toml\nindex c021f3..6b02d0 100644\n--- polkadot/node/metrics/Cargo.toml\n+++ polkadot/node/metrics/Cargo.toml\n@@ -41 +41,5 @@ runtime-metrics = []\n-runtime-benchmarks = []\n+runtime-benchmarks = [\n+\t\"primitives/runtime-benchmarks\",\n+\t\"polkadot-test-service/runtime-benchmarks\",\n+\t\"sc-service/runtime-benchmarks\"\n+]\ndiff --git polkadot/node/service/Cargo.toml polkadot/node/service/Cargo.toml\nindex f58f4a..8df0c3 100644\n--- polkadot/node/service/Cargo.toml\n+++ polkadot/node/service/Cargo.toml\n@@ -199,0 +200,14 @@ runtime-benchmarks = [\n+\t\"frame-benchmarking/runtime-benchmarks\",\n+\t\"frame-benchmarking-cli/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-babe/runtime-benchmarks\",\n+\t\"pallet-im-online/runtime-benchmarks\",\n+\t\"pallet-staking/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-primitives/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"polkadot-runtime-parachains/runtime-benchmarks\",\n+\t\"polkadot-test-client/runtime-benchmarks\",\n+\t\"sc-client-db/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git polkadot/node/test/client/Cargo.toml polkadot/node/test/client/Cargo.toml\nindex f63dd1..a65828 100644\n--- polkadot/node/test/client/Cargo.toml\n+++ polkadot/node/test/client/Cargo.toml\n@@ -41 +41,8 @@ futures = \"0.3.21\"\n-runtime-benchmarks=[ \"polkadot-test-runtime/runtime-benchmarks\" ]\n+runtime-benchmarks=[\n+\t\"polkadot-test-runtime/runtime-benchmarks\",\n+\t\"frame-benchmarking/runtime-benchmarks\",\n+\t\"polkadot-primitives/runtime-benchmarks\",\n+\t\"polkadot-test-service/runtime-benchmarks\",\n+\t\"sc-service/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\n+]\ndiff --git polkadot/node/test/performance-test/Cargo.toml polkadot/node/test/performance-test/Cargo.toml\nindex 0e3236..569419 100644\n--- polkadot/node/test/performance-test/Cargo.toml\n+++ polkadot/node/test/performance-test/Cargo.toml\n@@ -30 +30,4 @@ path = \"src/gen_ref_constants.rs\"\n-runtime-benchmarks = [ \"kusama-runtime/runtime-benchmarks\" ]\n+runtime-benchmarks = [\n+\t\"kusama-runtime/runtime-benchmarks\", \n+\t\"polkadot-primitives/runtime-benchmarks\"\n+]\ndiff --git polkadot/node/test/service/Cargo.toml polkadot/node/test/service/Cargo.toml\nindex c9cb59..fdeea4 100644\n--- polkadot/node/test/service/Cargo.toml\n+++ polkadot/node/test/service/Cargo.toml\n@@ -69,0 +70,9 @@ runtime-benchmarks= [\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"pallet-staking/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-primitives/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"polkadot-runtime-parachains/runtime-benchmarks\",\n+\t\"sc-service/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git polkadot/parachain/Cargo.toml polkadot/parachain/Cargo.toml\nindex 032004..a31e87 100644\n--- polkadot/parachain/Cargo.toml\n+++ polkadot/parachain/Cargo.toml\n@@ -40 +40,4 @@ std = [\n-runtime-benchmarks = []\n+runtime-benchmarks = [\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\n+]\ndiff --git polkadot/primitives/Cargo.toml polkadot/primitives/Cargo.toml\nindex be0531..cc9716 100644\n--- polkadot/primitives/Cargo.toml\n+++ polkadot/primitives/Cargo.toml\n@@ -53 +53,5 @@ std = [\n-runtime-benchmarks = []\n+runtime-benchmarks = [\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"runtime_primitives/runtime-benchmarks\",\n+\t\"sp-staking/runtime-benchmarks\"\n+]\ndiff --git polkadot/runtime/common/Cargo.toml polkadot/runtime/common/Cargo.toml\nindex 72b077..08e69b 100644\n--- polkadot/runtime/common/Cargo.toml\n+++ polkadot/runtime/common/Cargo.toml\n@@ -112,0 +113,10 @@ runtime-benchmarks = [\n+\t\"frame-election-provider-support/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"pallet-election-provider-multi-phase/runtime-benchmarks\",\n+\t\"pallet-staking/runtime-benchmarks\",\n+\t\"pallet-timestamp/runtime-benchmarks\",\n+\t\"pallet-treasury/runtime-benchmarks\",\n+\t\"pallet-vesting/runtime-benchmarks\",\n+\t\"primitives/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"sp-staking/runtime-benchmarks\"\ndiff --git polkadot/runtime/kusama/Cargo.toml polkadot/runtime/kusama/Cargo.toml\nindex d04f67..477798 100644\n--- polkadot/runtime/kusama/Cargo.toml\n+++ polkadot/runtime/kusama/Cargo.toml\n@@ -268,0 +269,6 @@ runtime-benchmarks = [\n+\t\"pallet-mmr/runtime-benchmarks\",\n+\t\"pallet-offences/runtime-benchmarks\",\n+\t\"pallet-state-trie-migration/runtime-benchmarks\",\n+\t\"primitives/runtime-benchmarks\",\n+\t\"sp-staking/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git polkadot/runtime/parachains/Cargo.toml polkadot/runtime/parachains/Cargo.toml\nindex f4f647..ff6dbf 100644\n--- polkadot/runtime/parachains/Cargo.toml\n+++ polkadot/runtime/parachains/Cargo.toml\n@@ -112,0 +113,4 @@ runtime-benchmarks = [\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"sp-staking/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git polkadot/runtime/polkadot/Cargo.toml polkadot/runtime/polkadot/Cargo.toml\nindex 1d2ce8..8b03f9 100644\n--- polkadot/runtime/polkadot/Cargo.toml\n+++ polkadot/runtime/polkadot/Cargo.toml\n@@ -247,0 +248,4 @@ runtime-benchmarks = [\n+\t\"pallet-offences/runtime-benchmarks\",\n+\t\"primitives/runtime-benchmarks\",\n+\t\"sp-staking/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git polkadot/runtime/rococo/Cargo.toml polkadot/runtime/rococo/Cargo.toml\nindex ebb7cd..c04a81 100644\n--- polkadot/runtime/rococo/Cargo.toml\n+++ polkadot/runtime/rococo/Cargo.toml\n@@ -224,0 +225,7 @@ runtime-benchmarks = [\n+\t\"pallet-mmr/runtime-benchmarks\",\n+\t\"pallet-offences/runtime-benchmarks\",\n+\t\"pallet-state-trie-migration/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"primitives/runtime-benchmarks\",\n+\t\"sp-staking/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git polkadot/runtime/test-runtime/Cargo.toml polkadot/runtime/test-runtime/Cargo.toml\nindex e5d04a..baf9dd 100644\n--- polkadot/runtime/test-runtime/Cargo.toml\n+++ polkadot/runtime/test-runtime/Cargo.toml\n@@ -141,0 +142,19 @@ runtime-benchmarks = [\n+\t\"frame-election-provider-support/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-babe/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"pallet-grandpa/runtime-benchmarks\",\n+\t\"pallet-indices/runtime-benchmarks\",\n+\t\"pallet-offences/runtime-benchmarks\",\n+\t\"pallet-staking/runtime-benchmarks\",\n+\t\"pallet-sudo/runtime-benchmarks\",\n+\t\"pallet-timestamp/runtime-benchmarks\",\n+\t\"pallet-vesting/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"primitives/runtime-benchmarks\",\n+\t\"runtime-common/runtime-benchmarks\",\n+\t\"polkadot-runtime-parachains/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"sp-staking/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git polkadot/runtime/westend/Cargo.toml polkadot/runtime/westend/Cargo.toml\nindex 40664e..f69add 100644\n--- polkadot/runtime/westend/Cargo.toml\n+++ polkadot/runtime/westend/Cargo.toml\n@@ -246,0 +247,8 @@ runtime-benchmarks = [\n+\t\"pallet-mmr/runtime-benchmarks\",\n+\t\"pallet-nomination-pools/runtime-benchmarks\",\n+\t\"pallet-offences/runtime-benchmarks\",\n+\t\"pallet-state-trie-migration/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"primitives/runtime-benchmarks\",\n+\t\"sp-staking/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml\nindex f6f993..0de909 100644\n--- polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml\n+++ polkadot/xcm/pallet-xcm-benchmarks/Cargo.toml\n@@ -56,0 +57,5 @@ runtime-benchmarks = [\n+\t\"pallet-assets/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"polkadot-primitives/runtime-benchmarks\",\n+\t\"polkadot-runtime-common/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git polkadot/xcm/pallet-xcm/Cargo.toml polkadot/xcm/pallet-xcm/Cargo.toml\nindex eefc3c..01a5b3 100644\n--- polkadot/xcm/pallet-xcm/Cargo.toml\n+++ polkadot/xcm/pallet-xcm/Cargo.toml\n@@ -56,0 +57,5 @@ runtime-benchmarks = [\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-parachains/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\ndiff --git polkadot/xcm/xcm-builder/Cargo.toml polkadot/xcm/xcm-builder/Cargo.toml\nindex 336162..494a34 100644\n--- polkadot/xcm/xcm-builder/Cargo.toml\n+++ polkadot/xcm/xcm-builder/Cargo.toml\n@@ -45,0 +46,8 @@ runtime-benchmarks = [\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"pallet-salary/runtime-benchmarks\",\n+\t\"pallet-xcm/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"primitives/runtime-benchmarks\",\n+\t\"polkadot-runtime-parachains/runtime-benchmarks\",\n+\t\"polkadot-test-runtime/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git polkadot/xcm/xcm-executor/Cargo.toml polkadot/xcm/xcm-executor/Cargo.toml\nindex de0ca1..0d39ba 100644\n--- polkadot/xcm/xcm-executor/Cargo.toml\n+++ polkadot/xcm/xcm-executor/Cargo.toml\n@@ -26 +26,5 @@ default = [ \"std\" ]\n-runtime-benchmarks = [ \"frame-benchmarking/runtime-benchmarks\" ]\n+runtime-benchmarks = [\n+\t\"frame-benchmarking/runtime-benchmarks\",\n+\t\"frame-support/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\"\n+]\ndiff --git polkadot/xcm/xcm-simulator/example/Cargo.toml polkadot/xcm/xcm-simulator/example/Cargo.toml\nindex 33a516..70545c 100644\n--- polkadot/xcm/xcm-simulator/example/Cargo.toml\n+++ polkadot/xcm/xcm-simulator/example/Cargo.toml\n@@ -46,0 +47 @@ runtime-benchmarks = [\n+\t\"sp-runtime/runtime-benchmarks\"\ndiff --git polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml\nindex a8e43d..261276 100644\n--- polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml\n+++ polkadot/xcm/xcm-simulator/fuzzer/Cargo.toml\n@@ -38,0 +39,6 @@ runtime-benchmarks = [\n+\t\"frame-system/runtime-benchmarks\",\n+\t\"pallet-balances/runtime-benchmarks\",\n+\t\"polkadot-parachain/runtime-benchmarks\",\n+\t\"polkadot-runtime-parachains/runtime-benchmarks\",\n+\t\"sp-runtime/runtime-benchmarks\",\n+\t\"xcm-executor/runtime-benchmarks\"\n"

--- a/tests/integration/substrate/frame-support.yaml
+++ b/tests/integration/substrate/frame-support.yaml
@@ -9,22 +9,17 @@ cases:
     crate 'frame-support'
       feature 'std'
         must propagate to:
-          frame-system
           once_cell
-          pretty_assertions
-          serde
-          serde_json
           sp-debug-derive
-    Found 6 issues (run with --fix to fix).
+    Found 2 issues (run with --fix to fix).
   code: 1
 - cmd: lint propagate-feature -p frame-support --feature std --workspace
   stdout: |
     crate 'frame-support'
       feature 'std'
         must propagate to:
-          frame-system
           sp-debug-derive
-    Found 2 issues (run with --fix to fix).
+    Found 1 issue (run with --fix to fix).
   code: 1
 - cmd: lint propagate-feature -p frame-support --feature try-runtime
   stdout: |

--- a/tests/integration/substrate/master-1.yaml
+++ b/tests/integration/substrate/master-1.yaml
@@ -1,6 +1,6 @@
 repo:
   name: substrate
-  ref: 033d4e86cc7eff0066cd376b9375f815761d653c
+  ref: 2cc2e05e78b1e9109669dc959ac7656eb46b3492
 cases:
 - cmd: lint propagate-feature --feature runtime-benchmarks
   stdout: |
@@ -12,11 +12,34 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           node-cli
+    crate 'frame-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          sp-runtime
+    crate 'frame-benchmarking-cli'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-support
+          frame-system
+          sc-service
+          sp-runtime
+    crate 'frame-benchmarking-pallet-pov'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          sp-runtime
     crate 'frame-election-provider-solution-type'
       feature 'runtime-benchmarks'
         is required by 2 dependencies:
           frame-election-provider-support
           frame-support
+    crate 'frame-election-provider-support'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
     crate 'frame-election-solution-type-fuzzer'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
@@ -32,7 +55,9 @@ cases:
           sp-runtime
     crate 'frame-remote-externalities'
       feature 'runtime-benchmarks'
-        is required by 1 dependency:
+        is required by 3 dependencies:
+          frame-support
+          pallet-elections-phragmen
           sp-runtime
     crate 'frame-support-test'
       feature 'runtime-benchmarks'
@@ -49,9 +74,12 @@ cases:
           sp-runtime
     crate 'frame-support-test-pallet'
       feature 'runtime-benchmarks'
-        is required by 3 dependencies:
+        is required by 2 dependencies:
           frame-support
           frame-system
+    crate 'frame-system-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
           sp-runtime
     crate 'frame-try-runtime'
       feature 'runtime-benchmarks'
@@ -60,11 +88,18 @@ cases:
           sp-runtime
     crate 'generate-bags'
       feature 'runtime-benchmarks'
-        is required by 5 dependencies:
+        is required by 4 dependencies:
           frame-election-provider-support
           frame-support
           frame-system
           pallet-staking
+    crate 'kitchensink-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          pallet-asset-tx-payment
+          pallet-nomination-pools
+          pallet-offences
           sp-staking
     crate 'mmr-gadget'
       feature 'runtime-benchmarks'
@@ -78,6 +113,18 @@ cases:
       feature 'runtime-benchmarks'
         is required by 2 dependencies:
           kitchensink-runtime
+          sp-runtime
+    crate 'node-cli'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-system
+          pallet-asset-tx-payment
+          pallet-assets
+          pallet-balances
+          pallet-im-online
+          pallet-timestamp
+          sc-client-db
+          sc-service
           sp-runtime
     crate 'node-executor'
       feature 'runtime-benchmarks'
@@ -101,7 +148,8 @@ cases:
           sp-runtime
     crate 'node-primitives'
       feature 'runtime-benchmarks'
-        is required by 1 dependency:
+        is required by 2 dependencies:
+          frame-system
           sp-runtime
     crate 'node-rpc'
       feature 'runtime-benchmarks'
@@ -111,26 +159,41 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           kitchensink-runtime
+    crate 'node-template'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-system
+          sc-service
+          sp-runtime
     crate 'node-testing'
       feature 'runtime-benchmarks'
-        is required by 8 dependencies:
+        is required by 7 dependencies:
           frame-system
           kitchensink-runtime
-          pallet-asset-conversion
           pallet-asset-tx-payment
           pallet-assets
           sc-client-db
           sc-service
           sp-runtime
-    crate 'pallet-asset-conversion-tx-payment'
+    crate 'pallet-alliance'
       feature 'runtime-benchmarks'
-        is required by 6 dependencies:
+        must propagate to:
+          pallet-balances
+    crate 'pallet-asset-rate'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+    crate 'pallet-asset-tx-payment'
+      feature 'runtime-benchmarks'
+        must propagate to:
           frame-support
-          frame-system
-          pallet-asset-conversion
           pallet-assets
           pallet-balances
-          sp-runtime
+    crate 'pallet-assets'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
     crate 'pallet-atomic-swap'
       feature 'runtime-benchmarks'
         is required by 4 dependencies:
@@ -157,6 +220,24 @@ cases:
           frame-support
           frame-system
           sp-runtime
+    crate 'pallet-babe'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-offences
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+          sp-staking
+    crate 'pallet-bags-list'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
     crate 'pallet-bags-list-fuzzer'
       feature 'runtime-benchmarks'
         is required by 2 dependencies:
@@ -170,6 +251,12 @@ cases:
           frame-system
           pallet-bags-list
           pallet-staking
+          sp-runtime
+    crate 'pallet-balances'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
           sp-runtime
     crate 'pallet-beefy'
       feature 'runtime-benchmarks'
@@ -191,16 +278,45 @@ cases:
           pallet-mmr
           sp-runtime
           sp-staking
+    crate 'pallet-bounties'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-child-bounties'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+          pallet-bounties
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-contracts'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-proxy
+          pallet-timestamp
+          pallet-utility
+          sp-runtime
     crate 'pallet-contracts-primitives'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
-    crate 'pallet-default-config-example'
+    crate 'pallet-conviction-voting'
       feature 'runtime-benchmarks'
-        is required by 3 dependencies:
-          frame-support
-          frame-system
-          sp-runtime
+        must propagate to:
+          pallet-balances
+          pallet-scheduler
+    crate 'pallet-democracy'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-preimage
+          pallet-scheduler
     crate 'pallet-dev-mode'
       feature 'runtime-benchmarks'
         is required by 4 dependencies:
@@ -221,24 +337,118 @@ cases:
           pallet-timestamp
           sp-runtime
           sp-staking
+    crate 'pallet-election-provider-multi-phase'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-election-provider-support-benchmarking
+          sp-runtime
+    crate 'pallet-election-provider-support-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-elections-phragmen'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
+    crate 'pallet-example-basic'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-example-offchain-worker'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
           frame-support
           frame-system
           sp-runtime
-    crate 'pallet-examples'
+    crate 'pallet-fast-unstake'
       feature 'runtime-benchmarks'
-        is required by 3 dependencies:
-          pallet-example-basic
-          pallet-example-kitchensink
-          pallet-example-split
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          pallet-balances
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-glutton'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
+    crate 'pallet-grandpa'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-offences
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+          sp-staking
+    crate 'pallet-identity'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
+    crate 'pallet-im-online'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+          sp-staking
+    crate 'pallet-indices'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
     crate 'pallet-insecure-randomness-collective-flip'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
           frame-support
           frame-system
           sp-runtime
+    crate 'pallet-lottery'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
+    crate 'pallet-message-queue'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          sp-runtime
+    crate 'pallet-mmr'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-multisig'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
+    crate 'pallet-nft-fractionalization'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-assets
+          pallet-balances
+          pallet-nfts
+    crate 'pallet-nfts'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
     crate 'pallet-nfts-runtime-api'
       feature 'runtime-benchmarks'
         is required by 2 dependencies:
@@ -251,12 +461,29 @@ cases:
           frame-system
           pallet-balances
           sp-runtime
+    crate 'pallet-nis'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
     crate 'pallet-node-authorization'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
           frame-support
           frame-system
           sp-runtime
+    crate 'pallet-nomination-pools'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-nomination-pools-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-timestamp
     crate 'pallet-nomination-pools-fuzzer'
       feature 'runtime-benchmarks'
         is required by 4 dependencies:
@@ -281,16 +508,81 @@ cases:
           pallet-timestamp
           sp-runtime
           sp-staking
-    crate 'pallet-paged-list-fuzzer'
+    crate 'pallet-offences'
       feature 'runtime-benchmarks'
-        is required by 2 dependencies:
+        must propagate to:
           frame-support
-          pallet-paged-list
+          frame-system
+          pallet-balances
+          sp-runtime
+          sp-staking
+    crate 'pallet-offences-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-babe
+          pallet-balances
+          pallet-grandpa
+          pallet-im-online
+          pallet-offences
+          pallet-timestamp
+          sp-runtime
+          sp-staking
+    crate 'pallet-preimage'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+          sp-runtime
+    crate 'pallet-proxy'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-utility
+          sp-runtime
+    crate 'pallet-recovery'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+    crate 'pallet-referenda'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+          pallet-preimage
+          pallet-scheduler
+    crate 'pallet-remark'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-root-offences'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+          sp-staking
     crate 'pallet-root-testing'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
           frame-support
           frame-system
+          sp-runtime
+    crate 'pallet-scheduler'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-preimage
           sp-runtime
     crate 'pallet-scored-pool'
       feature 'runtime-benchmarks'
@@ -307,9 +599,41 @@ cases:
           pallet-timestamp
           sp-runtime
           sp-staking
+    crate 'pallet-session-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-society'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
+    crate 'pallet-staking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-bags-list
+          pallet-balances
+          pallet-timestamp
+          sp-runtime
     crate 'pallet-staking-reward-curve'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
+          sp-runtime
+    crate 'pallet-state-trie-migration'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-support
+          frame-system
+          pallet-balances
           sp-runtime
     crate 'pallet-statement'
       feature 'runtime-benchmarks'
@@ -317,6 +641,28 @@ cases:
           frame-support
           frame-system
           pallet-balances
+          sp-runtime
+    crate 'pallet-sudo'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+    crate 'pallet-template'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-timestamp'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-tips'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-treasury
           sp-runtime
     crate 'pallet-transaction-payment'
       feature 'runtime-benchmarks'
@@ -332,6 +678,44 @@ cases:
     crate 'pallet-transaction-payment-rpc-runtime-api'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
+          sp-runtime
+    crate 'pallet-transaction-storage'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-treasury'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-utility
+          sp-runtime
+    crate 'pallet-uniques'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
+    crate 'pallet-utility'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-vesting'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-whitelist'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+          pallet-preimage
           sp-runtime
     crate 'sc-authority-discovery'
       feature 'runtime-benchmarks'
@@ -358,6 +742,11 @@ cases:
     crate 'sc-client-api'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
+          sp-runtime
+    crate 'sc-client-db'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          kitchensink-runtime
           sp-runtime
     crate 'sc-consensus'
       feature 'runtime-benchmarks'
@@ -435,6 +824,10 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
+    crate 'sc-network-statement'
+      feature 'runtime-benchmarks'
+        is required by 1 dependency:
+          sp-runtime
     crate 'sc-network-sync'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
@@ -469,6 +862,10 @@ cases:
     crate 'sc-runtime-test'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
+          sp-runtime
+    crate 'sc-service'
+      feature 'runtime-benchmarks'
+        must propagate to:
           sp-runtime
     crate 'sc-service-test'
       feature 'runtime-benchmarks'
@@ -512,6 +909,10 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
+    crate 'sp-application-crypto-test'
+      feature 'runtime-benchmarks'
+        is required by 1 dependency:
+          sp-runtime
     crate 'sp-authority-discovery'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
@@ -548,10 +949,6 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
-    crate 'sp-genesis-builder'
-      feature 'runtime-benchmarks'
-        is required by 1 dependency:
-          sp-runtime
     crate 'sp-inherents'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
@@ -585,6 +982,10 @@ cases:
         is required by 2 dependencies:
           sp-runtime
           sp-staking
+    crate 'sp-staking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          sp-runtime
     crate 'sp-state-machine'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
@@ -617,18 +1018,6 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
-    crate 'substrate'
-      feature 'runtime-benchmarks'
-        is required by 4 dependencies:
-          frame-support
-          node-cli
-          sc-service
-          sp-runtime
-    crate 'substrate-cli-test-utils'
-      feature 'runtime-benchmarks'
-        is required by 2 dependencies:
-          node-cli
-          sc-service
     crate 'substrate-frame-cli'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
@@ -661,11 +1050,12 @@ cases:
           sp-runtime
     crate 'substrate-test-runtime'
       feature 'runtime-benchmarks'
-        is required by 7 dependencies:
+        is required by 8 dependencies:
           frame-support
           frame-system
           pallet-babe
           pallet-balances
+          pallet-sudo
           pallet-timestamp
           sc-service
           sp-runtime
@@ -687,9 +1077,10 @@ cases:
           sc-service
     crate 'try-runtime-cli'
       feature 'runtime-benchmarks'
-        is required by 1 dependency:
+        is required by 2 dependencies:
+          sc-service
           sp-runtime
-    Found 283 issues (run with --fix to fix).
+    Found 494 issues (run with --fix to fix).
   code: 1
 - cmd: lint propagate-feature --feature runtime-benchmarks --workspace
   stdout: |
@@ -701,11 +1092,34 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           node-cli
+    crate 'frame-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          sp-runtime
+    crate 'frame-benchmarking-cli'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-support
+          frame-system
+          sc-service
+          sp-runtime
+    crate 'frame-benchmarking-pallet-pov'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          sp-runtime
     crate 'frame-election-provider-solution-type'
       feature 'runtime-benchmarks'
         is required by 2 dependencies:
           frame-election-provider-support
           frame-support
+    crate 'frame-election-provider-support'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
     crate 'frame-election-solution-type-fuzzer'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
@@ -721,7 +1135,9 @@ cases:
           sp-runtime
     crate 'frame-remote-externalities'
       feature 'runtime-benchmarks'
-        is required by 1 dependency:
+        is required by 3 dependencies:
+          frame-support
+          pallet-elections-phragmen
           sp-runtime
     crate 'frame-support-test'
       feature 'runtime-benchmarks'
@@ -738,9 +1154,12 @@ cases:
           sp-runtime
     crate 'frame-support-test-pallet'
       feature 'runtime-benchmarks'
-        is required by 3 dependencies:
+        is required by 2 dependencies:
           frame-support
           frame-system
+    crate 'frame-system-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
           sp-runtime
     crate 'frame-try-runtime'
       feature 'runtime-benchmarks'
@@ -749,11 +1168,18 @@ cases:
           sp-runtime
     crate 'generate-bags'
       feature 'runtime-benchmarks'
-        is required by 5 dependencies:
+        is required by 4 dependencies:
           frame-election-provider-support
           frame-support
           frame-system
           pallet-staking
+    crate 'kitchensink-runtime'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          pallet-asset-tx-payment
+          pallet-nomination-pools
+          pallet-offences
           sp-staking
     crate 'mmr-gadget'
       feature 'runtime-benchmarks'
@@ -767,6 +1193,18 @@ cases:
       feature 'runtime-benchmarks'
         is required by 2 dependencies:
           kitchensink-runtime
+          sp-runtime
+    crate 'node-cli'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-system
+          pallet-asset-tx-payment
+          pallet-assets
+          pallet-balances
+          pallet-im-online
+          pallet-timestamp
+          sc-client-db
+          sc-service
           sp-runtime
     crate 'node-executor'
       feature 'runtime-benchmarks'
@@ -790,7 +1228,8 @@ cases:
           sp-runtime
     crate 'node-primitives'
       feature 'runtime-benchmarks'
-        is required by 1 dependency:
+        is required by 2 dependencies:
+          frame-system
           sp-runtime
     crate 'node-rpc'
       feature 'runtime-benchmarks'
@@ -800,26 +1239,41 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           kitchensink-runtime
+    crate 'node-template'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-system
+          sc-service
+          sp-runtime
     crate 'node-testing'
       feature 'runtime-benchmarks'
-        is required by 8 dependencies:
+        is required by 7 dependencies:
           frame-system
           kitchensink-runtime
-          pallet-asset-conversion
           pallet-asset-tx-payment
           pallet-assets
           sc-client-db
           sc-service
           sp-runtime
-    crate 'pallet-asset-conversion-tx-payment'
+    crate 'pallet-alliance'
       feature 'runtime-benchmarks'
-        is required by 6 dependencies:
+        must propagate to:
+          pallet-balances
+    crate 'pallet-asset-rate'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+    crate 'pallet-asset-tx-payment'
+      feature 'runtime-benchmarks'
+        must propagate to:
           frame-support
-          frame-system
-          pallet-asset-conversion
           pallet-assets
           pallet-balances
-          sp-runtime
+    crate 'pallet-assets'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
     crate 'pallet-atomic-swap'
       feature 'runtime-benchmarks'
         is required by 4 dependencies:
@@ -846,6 +1300,24 @@ cases:
           frame-support
           frame-system
           sp-runtime
+    crate 'pallet-babe'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-offences
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+          sp-staking
+    crate 'pallet-bags-list'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
     crate 'pallet-bags-list-fuzzer'
       feature 'runtime-benchmarks'
         is required by 2 dependencies:
@@ -859,6 +1331,12 @@ cases:
           frame-system
           pallet-bags-list
           pallet-staking
+          sp-runtime
+    crate 'pallet-balances'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
           sp-runtime
     crate 'pallet-beefy'
       feature 'runtime-benchmarks'
@@ -880,16 +1358,45 @@ cases:
           pallet-mmr
           sp-runtime
           sp-staking
+    crate 'pallet-bounties'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-child-bounties'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+          pallet-bounties
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-contracts'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-proxy
+          pallet-timestamp
+          pallet-utility
+          sp-runtime
     crate 'pallet-contracts-primitives'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
-    crate 'pallet-default-config-example'
+    crate 'pallet-conviction-voting'
       feature 'runtime-benchmarks'
-        is required by 3 dependencies:
-          frame-support
-          frame-system
-          sp-runtime
+        must propagate to:
+          pallet-balances
+          pallet-scheduler
+    crate 'pallet-democracy'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-preimage
+          pallet-scheduler
     crate 'pallet-dev-mode'
       feature 'runtime-benchmarks'
         is required by 4 dependencies:
@@ -910,24 +1417,118 @@ cases:
           pallet-timestamp
           sp-runtime
           sp-staking
+    crate 'pallet-election-provider-multi-phase'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-election-provider-support-benchmarking
+          sp-runtime
+    crate 'pallet-election-provider-support-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-elections-phragmen'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
+    crate 'pallet-example-basic'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-example-offchain-worker'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
           frame-support
           frame-system
           sp-runtime
-    crate 'pallet-examples'
+    crate 'pallet-fast-unstake'
       feature 'runtime-benchmarks'
-        is required by 3 dependencies:
-          pallet-example-basic
-          pallet-example-kitchensink
-          pallet-example-split
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          pallet-balances
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-glutton'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
+    crate 'pallet-grandpa'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-offences
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+          sp-staking
+    crate 'pallet-identity'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
+    crate 'pallet-im-online'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+          sp-staking
+    crate 'pallet-indices'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
     crate 'pallet-insecure-randomness-collective-flip'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
           frame-support
           frame-system
           sp-runtime
+    crate 'pallet-lottery'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
+    crate 'pallet-message-queue'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          sp-runtime
+    crate 'pallet-mmr'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-multisig'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
+    crate 'pallet-nft-fractionalization'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-assets
+          pallet-balances
+          pallet-nfts
+    crate 'pallet-nfts'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
     crate 'pallet-nfts-runtime-api'
       feature 'runtime-benchmarks'
         is required by 2 dependencies:
@@ -940,12 +1541,29 @@ cases:
           frame-system
           pallet-balances
           sp-runtime
+    crate 'pallet-nis'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          sp-runtime
     crate 'pallet-node-authorization'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
           frame-support
           frame-system
           sp-runtime
+    crate 'pallet-nomination-pools'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-nomination-pools-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-timestamp
     crate 'pallet-nomination-pools-fuzzer'
       feature 'runtime-benchmarks'
         is required by 4 dependencies:
@@ -970,16 +1588,81 @@ cases:
           pallet-timestamp
           sp-runtime
           sp-staking
-    crate 'pallet-paged-list-fuzzer'
+    crate 'pallet-offences'
       feature 'runtime-benchmarks'
-        is required by 2 dependencies:
+        must propagate to:
           frame-support
-          pallet-paged-list
+          frame-system
+          pallet-balances
+          sp-runtime
+          sp-staking
+    crate 'pallet-offences-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-babe
+          pallet-balances
+          pallet-grandpa
+          pallet-im-online
+          pallet-offences
+          pallet-timestamp
+          sp-runtime
+          sp-staking
+    crate 'pallet-preimage'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+          sp-runtime
+    crate 'pallet-proxy'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-utility
+          sp-runtime
+    crate 'pallet-recovery'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+    crate 'pallet-referenda'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+          pallet-preimage
+          pallet-scheduler
+    crate 'pallet-remark'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-root-offences'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+          sp-staking
     crate 'pallet-root-testing'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
           frame-support
           frame-system
+          sp-runtime
+    crate 'pallet-scheduler'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-preimage
           sp-runtime
     crate 'pallet-scored-pool'
       feature 'runtime-benchmarks'
@@ -996,9 +1679,41 @@ cases:
           pallet-timestamp
           sp-runtime
           sp-staking
+    crate 'pallet-session-benchmarking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-election-provider-support
+          frame-support
+          frame-system
+          pallet-balances
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-society'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
+    crate 'pallet-staking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-bags-list
+          pallet-balances
+          pallet-timestamp
+          sp-runtime
     crate 'pallet-staking-reward-curve'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
+          sp-runtime
+    crate 'pallet-state-trie-migration'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          frame-support
+          frame-system
+          pallet-balances
           sp-runtime
     crate 'pallet-statement'
       feature 'runtime-benchmarks'
@@ -1006,6 +1721,28 @@ cases:
           frame-support
           frame-system
           pallet-balances
+          sp-runtime
+    crate 'pallet-sudo'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+    crate 'pallet-template'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-timestamp'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
+    crate 'pallet-tips'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-treasury
           sp-runtime
     crate 'pallet-transaction-payment'
       feature 'runtime-benchmarks'
@@ -1021,6 +1758,44 @@ cases:
     crate 'pallet-transaction-payment-rpc-runtime-api'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
+          sp-runtime
+    crate 'pallet-transaction-storage'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-treasury'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-utility
+          sp-runtime
+    crate 'pallet-uniques'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          pallet-balances
+    crate 'pallet-utility'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          pallet-balances
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-vesting'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-support
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-whitelist'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          frame-benchmarking
+          pallet-balances
+          pallet-preimage
           sp-runtime
     crate 'sc-authority-discovery'
       feature 'runtime-benchmarks'
@@ -1047,6 +1822,11 @@ cases:
     crate 'sc-client-api'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
+          sp-runtime
+    crate 'sc-client-db'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          kitchensink-runtime
           sp-runtime
     crate 'sc-consensus'
       feature 'runtime-benchmarks'
@@ -1124,6 +1904,10 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
+    crate 'sc-network-statement'
+      feature 'runtime-benchmarks'
+        is required by 1 dependency:
+          sp-runtime
     crate 'sc-network-sync'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
@@ -1158,6 +1942,10 @@ cases:
     crate 'sc-runtime-test'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
+          sp-runtime
+    crate 'sc-service'
+      feature 'runtime-benchmarks'
+        must propagate to:
           sp-runtime
     crate 'sc-service-test'
       feature 'runtime-benchmarks'
@@ -1201,6 +1989,10 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
+    crate 'sp-application-crypto-test'
+      feature 'runtime-benchmarks'
+        is required by 1 dependency:
+          sp-runtime
     crate 'sp-authority-discovery'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
@@ -1237,10 +2029,6 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
-    crate 'sp-genesis-builder'
-      feature 'runtime-benchmarks'
-        is required by 1 dependency:
-          sp-runtime
     crate 'sp-inherents'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
@@ -1274,6 +2062,10 @@ cases:
         is required by 2 dependencies:
           sp-runtime
           sp-staking
+    crate 'sp-staking'
+      feature 'runtime-benchmarks'
+        must propagate to:
+          sp-runtime
     crate 'sp-state-machine'
       feature 'runtime-benchmarks'
         is required by 1 dependency:
@@ -1306,18 +2098,6 @@ cases:
       feature 'runtime-benchmarks'
         is required by 1 dependency:
           sp-runtime
-    crate 'substrate'
-      feature 'runtime-benchmarks'
-        is required by 4 dependencies:
-          frame-support
-          node-cli
-          sc-service
-          sp-runtime
-    crate 'substrate-cli-test-utils'
-      feature 'runtime-benchmarks'
-        is required by 2 dependencies:
-          node-cli
-          sc-service
     crate 'substrate-frame-cli'
       feature 'runtime-benchmarks'
         is required by 3 dependencies:
@@ -1350,11 +2130,12 @@ cases:
           sp-runtime
     crate 'substrate-test-runtime'
       feature 'runtime-benchmarks'
-        is required by 7 dependencies:
+        is required by 8 dependencies:
           frame-support
           frame-system
           pallet-babe
           pallet-balances
+          pallet-sudo
           pallet-timestamp
           sc-service
           sp-runtime
@@ -1376,9 +2157,10 @@ cases:
           sc-service
     crate 'try-runtime-cli'
       feature 'runtime-benchmarks'
-        is required by 1 dependency:
+        is required by 2 dependencies:
+          sc-service
           sp-runtime
-    Found 283 issues (run with --fix to fix).
+    Found 494 issues (run with --fix to fix).
   code: 1
 - cmd: lint propagate-feature --feature std
   stdout: |
@@ -1449,13 +2231,6 @@ cases:
       feature 'std'
         must propagate to:
           num-traits
-    crate 'ark-algebra-test-templates'
-      feature 'std'
-        must propagate to:
-          num-bigint
-          num-integer
-          num-traits
-          sha2
     crate 'ark-bls12-381'
       feature 'std'
         must propagate to:
@@ -1482,28 +2257,6 @@ cases:
       feature 'std'
         must propagate to:
           ark-serialize
-    crate 'ark-r1cs-std'
-      feature 'std'
-        must propagate to:
-          ark-ec
-          num-integer
-          num-traits
-          tracing
-    crate 'ark-scale'
-      feature 'std'
-        must propagate to:
-          ark-ec
-    crate 'ark-secret-scalar'
-      feature 'std'
-        is required by 8 dependencies:
-          ark-ec
-          ark-ff
-          ark-serialize
-          ark-std
-          ark-transcript
-          digest
-          rand_core
-          zeroize
     crate 'ark-serialize'
       feature 'std'
         must propagate to:
@@ -1513,15 +2266,6 @@ cases:
       feature 'std'
         must propagate to:
           num-traits
-    crate 'ark-transcript'
-      feature 'std'
-        must propagate to:
-          ark-ff
-          ark-serialize
-          ark-std
-          digest
-          rand_core
-          sha3
     crate 'asn1-rs'
       feature 'std'
         must propagate to:
@@ -1573,22 +2317,6 @@ cases:
           miniz_oxide
           object
           rustc-demangle
-    crate 'bandersnatch_vrfs'
-      feature 'std'
-        is required by 13 dependencies:
-          ark-bls12-381
-          ark-ec
-          ark-ed-on-bls12-381-bandersnatch
-          ark-ff
-          ark-serialize
-          ark-std
-          fflonk
-          merlin
-          rand_chacha
-          rand_core
-          ring
-          sha2
-          zeroize
     crate 'basic-toml'
       feature 'std'
         is required by 1 dependency:
@@ -1632,6 +2360,10 @@ cases:
       feature 'std'
         must propagate to:
           cipher
+    crate 'bounded-collections'
+      feature 'std'
+        must propagate to:
+          serde
     crate 'bstr'
       feature 'std'
         must propagate to:
@@ -1684,6 +2416,7 @@ cases:
     crate 'chrono'
       feature 'std'
         must propagate to:
+          num-integer
           num-traits
           winapi
     crate 'ciborium'
@@ -1727,11 +2460,6 @@ cases:
           encode_unicode
           libc
           unicode-width
-    crate 'const-random-macro'
-      feature 'std'
-        is required by 2 dependencies:
-          getrandom
-          once_cell
     crate 'core-foundation'
       feature 'std'
         is required by 1 dependency:
@@ -1824,8 +2552,7 @@ cases:
           zeroize
     crate 'curve25519-dalek'
       feature 'std'
-        is required by 5 dependencies:
-          digest
+        is required by 4 dependencies:
           fiat-crypto
           platforms
           subtle
@@ -1880,22 +2607,6 @@ cases:
         is required by 2 dependencies:
           libc
           winapi
-    crate 'dleq_vrf'
-      feature 'std'
-        is required by 8 dependencies:
-          ark-ec
-          ark-ff
-          ark-serialize
-          ark-std
-          ark-transcript
-          arrayvec
-          rand_core
-          zeroize
-    crate 'docify_macros'
-      feature 'std'
-        is required by 2 dependencies:
-          once_cell
-          regex
     crate 'ecdsa'
       feature 'std'
         must propagate to:
@@ -1905,15 +2616,6 @@ cases:
         must propagate to:
           der
           digest
-          spki
-    crate 'ed25519'
-      feature 'std'
-        must propagate to:
-          pkcs8
-    crate 'ed25519-dalek'
-      feature 'std'
-        must propagate to:
-          zeroize
     crate 'ed25519-dalek'
       feature 'std'
         must propagate to:
@@ -2013,9 +2715,13 @@ cases:
       feature 'std'
         is required by 1 dependency:
           num
+    crate 'frame-benchmarking'
+      feature 'std'
+        must propagate to:
+          frame-support-procedural
     crate 'frame-benchmarking-cli'
       feature 'std'
-        is required by 22 dependencies:
+        is required by 21 dependencies:
           chrono
           clap
           frame-benchmarking
@@ -2031,13 +2737,12 @@ cases:
           sp-core
           sp-externalities
           sp-inherents
-          sp-io
           sp-keystore
           sp-runtime
           sp-state-machine
+          sp-std
           sp-storage
           sp-trie
-          sp-wasm-interface
     crate 'frame-election-provider-solution-type'
       feature 'std'
         is required by 5 dependencies:
@@ -2058,22 +2763,32 @@ cases:
           sp-arithmetic
           sp-npos-elections
           sp-runtime
+    crate 'frame-executive'
+      feature 'std'
+        must propagate to:
+          frame-try-runtime
     crate 'frame-remote-externalities'
       feature 'std'
-        is required by 9 dependencies:
+        is required by 10 dependencies:
+          frame-support
           futures
           log
+          pallet-elections-phragmen
           codec (renamed from parity-scale-codec)
           serde
           sp-core
           sp-io
           sp-runtime
-          sp-state-machine
-          sp-tracing
+          tracing-subscriber
     crate 'frame-support'
       feature 'std'
         must propagate to:
-          serde_json
+          once_cell
+          sp-debug-derive
+    crate 'frame-support-test'
+      feature 'std'
+        must propagate to:
+          test-pallet (renamed from frame-support-test-pallet)
     crate 'fs2'
       feature 'std'
         is required by 2 dependencies:
@@ -2113,14 +2828,13 @@ cases:
           byteorder
     crate 'generate-bags'
       feature 'std'
-        is required by 7 dependencies:
+        is required by 6 dependencies:
           chrono
           frame-election-provider-support
           frame-support
           frame-system
           num-format
           pallet-staking
-          sp-staking
     crate 'generic-array'
       feature 'std'
         is required by 1 dependency:
@@ -2139,11 +2853,15 @@ cases:
         must propagate to:
           libc
           wasi
-          wasm-bindgen
     crate 'gimli'
       feature 'std'
         must propagate to:
           indexmap
+    crate 'git2'
+      feature 'std'
+        is required by 2 dependencies:
+          libc
+          log
     crate 'globset'
       feature 'std'
         is required by 5 dependencies:
@@ -2241,13 +2959,21 @@ cases:
           tracing
     crate 'hyper-rustls'
       feature 'std'
-        is required by 2 dependencies:
-          futures-util
+        is required by 1 dependency:
           log
     crate 'iana-time-zone'
       feature 'std'
         is required by 1 dependency:
           wasm-bindgen
+    crate 'iana-time-zone-haiku'
+      feature 'std'
+        is required by 1 dependency:
+          cxx
+    crate 'idna'
+      feature 'std'
+        is required by 2 dependencies:
+          unicode-bidi
+          unicode-normalization
     crate 'idna'
       feature 'std'
         is required by 2 dependencies:
@@ -2264,11 +2990,6 @@ cases:
           fnv
           futures
           log
-    crate 'impl-num-traits'
-      feature 'std'
-        is required by 2 dependencies:
-          num-traits
-          uint
     crate 'indexmap'
       feature 'std'
         must propagate to:
@@ -2310,11 +3031,6 @@ cases:
       feature 'std'
         is required by 1 dependency:
           wasm-bindgen
-    crate 'json-patch'
-      feature 'std'
-        is required by 2 dependencies:
-          serde
-          serde_json
     crate 'jsonrpsee'
       feature 'std'
         is required by 1 dependency:
@@ -2362,14 +3078,14 @@ cases:
       feature 'std'
         must propagate to:
           sha2
-    crate 'kitchensink-runtime'
-      feature 'std'
-        must propagate to:
-          primitive-types
     crate 'kvdb-rocksdb'
       feature 'std'
         is required by 1 dependency:
           regex
+    crate 'libgit2-sys'
+      feature 'std'
+        is required by 1 dependency:
+          libc
     crate 'libloading'
       feature 'std'
         is required by 1 dependency:
@@ -2545,6 +3261,14 @@ cases:
       feature 'std'
         is required by 1 dependency:
           libsecp256k1-core
+    crate 'libssh2-sys'
+      feature 'std'
+        is required by 1 dependency:
+          libc
+    crate 'libz-sys'
+      feature 'std'
+        is required by 1 dependency:
+          libc
     crate 'linregress'
       feature 'std'
         is required by 1 dependency:
@@ -2565,6 +3289,10 @@ cases:
       feature 'std'
         is required by 1 dependency:
           regex-automata
+    crate 'matchers'
+      feature 'std'
+        is required by 1 dependency:
+          regex-automata
     crate 'memfd'
       feature 'std'
         is required by 1 dependency:
@@ -2573,10 +3301,6 @@ cases:
       feature 'std'
         is required by 1 dependency:
           libc
-    crate 'merlin'
-      feature 'std'
-        must propagate to:
-          zeroize
     crate 'merlin'
       feature 'std'
         must propagate to:
@@ -2591,8 +3315,9 @@ cases:
           adler
     crate 'mio'
       feature 'std'
-        is required by 2 dependencies:
+        is required by 3 dependencies:
           libc
+          log
           wasi
     crate 'mmr-gadget'
       feature 'std'
@@ -2623,13 +3348,12 @@ cases:
           downcast
     crate 'multiaddr'
       feature 'std'
-        is required by 8 dependencies:
+        is required by 7 dependencies:
           byteorder
           data-encoding
           log
           multibase
           multihash
-          percent-encoding
           serde
           unsigned-varint
     crate 'multibase'
@@ -2646,6 +3370,12 @@ cases:
           digest
           sha-2 (renamed from sha2)
           sha-3 (renamed from sha3)
+    crate 'multihash'
+      feature 'std'
+        must propagate to:
+          core2
+          digest
+          sha-2 (renamed from sha2)
     crate 'multistream-select'
       feature 'std'
         is required by 4 dependencies:
@@ -2731,12 +3461,12 @@ cases:
           kitchensink-runtime
           log
           node-primitives
-          pallet-asset-conversion-tx-payment
           pallet-asset-tx-payment
           pallet-assets
           pallet-balances
           pallet-im-online
           pallet-timestamp
+          pallet-transaction-payment
           codec (renamed from parity-scale-codec)
           platforms
           rand
@@ -2753,9 +3483,9 @@ cases:
           sp-io
           sp-keystore
           sp-runtime
-          sp-statement-store
           sp-timestamp
           sp-tracing
+          sp-transaction-pool
           sp-transaction-storage-proof
     crate 'node-executor'
       feature 'std'
@@ -2790,9 +3520,10 @@ cases:
           sp-trie
     crate 'node-inspect'
       feature 'std'
-        is required by 4 dependencies:
+        is required by 5 dependencies:
           clap
           codec (renamed from parity-scale-codec)
+          sc-executor
           sp-core
           sp-runtime
     crate 'node-rpc'
@@ -2835,16 +3566,15 @@ cases:
           clap
     crate 'node-testing'
       feature 'std'
-        is required by 18 dependencies:
+        is required by 17 dependencies:
           frame-system
           futures
           kitchensink-runtime
           log
           node-primitives
-          pallet-asset-conversion
-          pallet-asset-conversion-tx-payment
           pallet-asset-tx-payment
           pallet-assets
+          pallet-transaction-payment
           codec (renamed from parity-scale-codec)
           sc-executor
           sp-api
@@ -2854,6 +3584,10 @@ cases:
           sp-io
           sp-runtime
           sp-timestamp
+    crate 'nu-ansi-term'
+      feature 'std'
+        is required by 1 dependency:
+          winapi
     crate 'num-format'
       feature 'std'
         must propagate to:
@@ -2879,6 +3613,10 @@ cases:
       feature 'std'
         is required by 1 dependency:
           asn1-rs
+    crate 'openssl-sys'
+      feature 'std'
+        is required by 1 dependency:
+          libc
     crate 'output_vt100'
       feature 'std'
         is required by 1 dependency:
@@ -2891,10 +3629,14 @@ cases:
       feature 'std'
         must propagate to:
           sha2
-    crate 'pallet-asset-conversion'
+    crate 'pallet-asset-tx-payment'
       feature 'std'
         must propagate to:
-          primitive-types
+          sp-storage
+    crate 'pallet-aura'
+      feature 'std'
+        must propagate to:
+          sp-core
     crate 'pallet-bags-list-fuzzer'
       feature 'std'
         is required by 3 dependencies:
@@ -2915,10 +3657,22 @@ cases:
           sp-std
           sp-storage
           sp-tracing
+    crate 'pallet-contracts'
+      feature 'std'
+        must propagate to:
+          sp-api
+    crate 'pallet-contracts-primitives'
+      feature 'std'
+        must propagate to:
+          sp-weights
     crate 'pallet-democracy'
       feature 'std'
         must propagate to:
           log
+    crate 'pallet-dev-mode'
+      feature 'std'
+        must propagate to:
+          sp-core
     crate 'pallet-election-provider-e2e-test'
       feature 'std'
         is required by 19 dependencies:
@@ -2941,6 +3695,14 @@ cases:
           sp-staking
           sp-std
           sp-tracing
+    crate 'pallet-example-basic'
+      feature 'std'
+        must propagate to:
+          sp-core
+    crate 'pallet-fast-unstake'
+      feature 'std'
+        must propagate to:
+          sp-core
     crate 'pallet-glutton'
       feature 'std'
         must propagate to:
@@ -2964,6 +3726,7 @@ cases:
     crate 'pallet-nomination-pools-benchmarking'
       feature 'std'
         must propagate to:
+          pallet-balances
           codec (renamed from parity-scale-codec)
           scale-info
     crate 'pallet-nomination-pools-fuzzer'
@@ -2997,20 +3760,26 @@ cases:
           sp-staking
           sp-std
           sp-tracing
-    crate 'pallet-paged-list-fuzzer'
-      feature 'std'
-        is required by 3 dependencies:
-          frame-support
-          pallet-paged-list
-          sp-io
     crate 'pallet-referenda'
       feature 'std'
         must propagate to:
           log
-    crate 'pallet-society'
+    crate 'pallet-root-offences'
       feature 'std'
         must propagate to:
-          log
+          sp-io
+          sp-staking
+          sp-std
+    crate 'pallet-root-testing'
+      feature 'std'
+        must propagate to:
+          sp-core
+          sp-io
+          sp-std
+    crate 'pallet-scheduler'
+      feature 'std'
+        must propagate to:
+          sp-core
     crate 'pallet-staking-reward-curve'
       feature 'std'
         is required by 1 dependency:
@@ -3028,6 +3797,14 @@ cases:
           sp-core
           sp-runtime
           sp-weights
+    crate 'pallet-transaction-storage'
+      feature 'std'
+        must propagate to:
+          sp-core
+    crate 'pallet-vesting'
+      feature 'std'
+        must propagate to:
+          sp-io
     crate 'parity-db'
       feature 'std'
         is required by 7 dependencies:
@@ -3281,24 +4058,10 @@ cases:
           log
           ring
           webpki
-    crate 'rustls'
-      feature 'std'
-        is required by 3 dependencies:
-          log
-          ring
-          webpki (renamed from rustls-webpki)
     crate 'rustls-pemfile'
       feature 'std'
         is required by 1 dependency:
           base64
-    crate 'rustls-webpki'
-      feature 'std'
-        must propagate to:
-          ring
-    crate 'rustls-webpki'
-      feature 'std'
-        must propagate to:
-          ring
     crate 'rusty-fork'
       feature 'std'
         is required by 1 dependency:
@@ -3376,7 +4139,7 @@ cases:
           sp-version
     crate 'sc-client-api'
       feature 'std'
-        is required by 14 dependencies:
+        is required by 15 dependencies:
           fnv
           futures
           log
@@ -3385,6 +4148,7 @@ cases:
           sp-api
           sp-core
           sp-externalities
+          sp-keystore
           sp-runtime
           sp-state-machine
           sp-statement-store
@@ -3578,10 +4342,11 @@ cases:
           wasm-instrument
     crate 'sc-executor-wasmtime'
       feature 'std'
-        is required by 9 dependencies:
+        is required by 10 dependencies:
           anyhow
           libc
           log
+          once_cell
           codec (renamed from parity-scale-codec)
           rustix
           sc-runtime-test
@@ -3633,11 +4398,14 @@ cases:
           unsigned-varint
     crate 'sc-network-common'
       feature 'std'
-        is required by 4 dependencies:
+        is required by 7 dependencies:
+          bytes
           futures
           codec (renamed from parity-scale-codec)
+          serde
           sp-consensus-grandpa
           sp-runtime
+          zeroize
     crate 'sc-network-gossip'
       feature 'std'
         is required by 5 dependencies:
@@ -3657,10 +4425,11 @@ cases:
           sp-runtime
     crate 'sc-network-statement'
       feature 'std'
-        is required by 4 dependencies:
+        is required by 5 dependencies:
           futures
           log
           codec (renamed from parity-scale-codec)
+          sp-runtime
           sp-statement-store
     crate 'sc-network-sync'
       feature 'std'
@@ -3677,10 +4446,11 @@ cases:
           sp-tracing
     crate 'sc-network-test'
       feature 'std'
-        is required by 7 dependencies:
+        is required by 8 dependencies:
           futures
           log
           rand
+          sp-consensus-babe
           sp-core
           sp-runtime
           sp-tracing
@@ -3694,33 +4464,38 @@ cases:
           sp-runtime
     crate 'sc-offchain'
       feature 'std'
-        is required by 15 dependencies:
+        is required by 12 dependencies:
           bytes
           fnv
           futures
-          log
           once_cell
           codec (renamed from parity-scale-codec)
           rand
           sp-api
           sp-core
-          sp-externalities
-          sp-keystore
           sp-offchain
           sp-runtime
           sp-tracing
           tracing
+    crate 'sc-peerset'
+      feature 'std'
+        is required by 6 dependencies:
+          futures
+          log
+          rand
+          serde_json
+          sp-arithmetic
+          sp-tracing
     crate 'sc-proposer-metrics'
       feature 'std'
         is required by 1 dependency:
           log
     crate 'sc-rpc'
       feature 'std'
-        is required by 14 dependencies:
+        is required by 13 dependencies:
           futures
           log
           codec (renamed from parity-scale-codec)
-          pretty_assertions
           serde_json
           sp-api
           sp-core
@@ -3748,13 +4523,12 @@ cases:
           serde_json
     crate 'sc-rpc-spec-v2'
       feature 'std'
-        is required by 13 dependencies:
+        is required by 12 dependencies:
           futures
           futures-util
           hex
           log
           codec (renamed from parity-scale-codec)
-          pretty_assertions
           serde
           serde_json
           sp-api
@@ -3762,6 +4536,10 @@ cases:
           sp-runtime
           sp-version
           substrate-test-runtime
+    crate 'sc-runtime-test'
+      feature 'std'
+        must propagate to:
+          sp-runtime-interface
     crate 'sc-service'
       feature 'std'
         is required by 22 dependencies:
@@ -3811,16 +4589,20 @@ cases:
           sp-core
     crate 'sc-statement-store'
       feature 'std'
-        is required by 5 dependencies:
+        is required by 8 dependencies:
+          futures
           log
+          codec (renamed from parity-scale-codec)
           sp-api
           sp-core
           sp-runtime
           sp-statement-store
+          sp-tracing
     crate 'sc-storage-monitor'
       feature 'std'
-        is required by 3 dependencies:
+        is required by 4 dependencies:
           clap
+          futures
           log
           sp-core
     crate 'sc-sync-state-rpc'
@@ -3855,10 +4637,11 @@ cases:
           serde_json
     crate 'sc-tracing'
       feature 'std'
-        is required by 12 dependencies:
+        is required by 13 dependencies:
           chrono
           libc
           log
+          once_cell
           regex
           rustc-hash
           serde
@@ -3870,9 +4653,10 @@ cases:
           tracing-log
     crate 'sc-transaction-pool'
       feature 'std'
-        is required by 10 dependencies:
+        is required by 11 dependencies:
           futures
           log
+          num-traits
           codec (renamed from parity-scale-codec)
           serde
           sp-api
@@ -3883,13 +4667,11 @@ cases:
           substrate-test-runtime
     crate 'sc-transaction-pool-api'
       feature 'std'
-        is required by 7 dependencies:
+        is required by 5 dependencies:
           futures
           log
-          codec (renamed from parity-scale-codec)
           serde
           serde_json
-          sp-core
           sp-runtime
     crate 'sc-utils'
       feature 'std'
@@ -4010,33 +4792,23 @@ cases:
           blake2
     crate 'sp-api-test'
       feature 'std'
-        is required by 10 dependencies:
-          futures
+        must propagate to:
           log
-          codec (renamed from parity-scale-codec)
-          scale-info
-          sp-api
-          sp-core
-          sp-runtime
-          sp-state-machine
-          sp-tracing
-          sp-version
     crate 'sp-application-crypto-test'
       feature 'std'
-        is required by 4 dependencies:
+        is required by 5 dependencies:
           sp-api
           sp-application-crypto
           sp-core
           sp-keystore
+          sp-runtime
     crate 'sp-arithmetic-fuzzer'
       feature 'std'
-        is required by 2 dependencies:
+        is required by 4 dependencies:
           num-bigint
+          num-traits
+          primitive-types
           sp-arithmetic
-    crate 'sp-ark-ed-on-bls12-381-bandersnatch'
-      feature 'std'
-        must propagate to:
-          ark-ec
     crate 'sp-blockchain'
       feature 'std'
         is required by 6 dependencies:
@@ -4056,10 +4828,18 @@ cases:
           sp-runtime
           sp-state-machine
           sp-test-primitives
+    crate 'sp-consensus-babe'
+      feature 'std'
+        must propagate to:
+          sp-keystore
     crate 'sp-consensus-beefy'
       feature 'std'
         must propagate to:
           strum
+    crate 'sp-consensus-grandpa'
+      feature 'std'
+        must propagate to:
+          sp-keystore
     crate 'sp-core'
       feature 'std'
         must propagate to:
@@ -4069,15 +4849,12 @@ cases:
       feature 'std'
         is required by 1 dependency:
           sp-core-hashing
-    crate 'sp-crypto-ec-utils'
-      feature 'std'
-        must propagate to:
-          sp-ark-models
     crate 'sp-io'
       feature 'std'
         must propagate to:
           ed25519-dalek
           log
+          sp-keystore
     crate 'sp-keyring'
       feature 'std'
         is required by 3 dependencies:
@@ -4090,9 +4867,11 @@ cases:
           scale-info
     crate 'sp-npos-elections-fuzzer'
       feature 'std'
-        is required by 4 dependencies:
+        is required by 6 dependencies:
           clap
+          codec (renamed from parity-scale-codec)
           rand
+          scale-info
           sp-npos-elections
           sp-runtime
     crate 'sp-panic-handler'
@@ -4126,8 +4905,16 @@ cases:
     crate 'sp-statement-store'
       feature 'std'
         must propagate to:
-          aes-gcm
-          hkdf
+          log
+          sp-externalities
+    crate 'sp-timestamp'
+      feature 'std'
+        must propagate to:
+          log
+    crate 'sp-transaction-storage-proof'
+      feature 'std'
+        must propagate to:
+          log
     crate 'sp-version-proc-macro'
       feature 'std'
         is required by 2 dependencies:
@@ -4174,11 +4961,6 @@ cases:
       feature 'std'
         is required by 1 dependency:
           clap
-    crate 'substrate'
-      feature 'std'
-        is required by 2 dependencies:
-          frame-support
-          sp-runtime
     crate 'substrate-bip39'
       feature 'std'
         is required by 5 dependencies:
@@ -4187,6 +4969,10 @@ cases:
           schnorrkel
           sha2
           zeroize
+    crate 'substrate-build-script-utils'
+      feature 'std'
+        is required by 1 dependency:
+          platforms
     crate 'substrate-cli-test-utils'
       feature 'std'
         is required by 3 dependencies:
@@ -4237,8 +5023,10 @@ cases:
           sp-runtime
     crate 'substrate-state-trie-migration-rpc'
       feature 'std'
-        is required by 8 dependencies:
+        is required by 10 dependencies:
+          log
           codec (renamed from parity-scale-codec)
+          scale-info
           serde
           serde_json
           sp-core
@@ -4261,12 +5049,12 @@ cases:
     crate 'substrate-test-runtime'
       feature 'std'
         must propagate to:
-          serde
-          serde_json
+          frame-executive
     crate 'substrate-test-runtime-client'
       feature 'std'
-        is required by 5 dependencies:
+        is required by 6 dependencies:
           futures
+          codec (renamed from parity-scale-codec)
           sp-api
           sp-core
           sp-runtime
@@ -4283,8 +5071,7 @@ cases:
           futures
     crate 'substrate-wasm-builder'
       feature 'std'
-        is required by 2 dependencies:
-          parity-wasm
+        is required by 1 dependency:
           strum
     crate 'system-configuration-sys'
       feature 'std'
@@ -4347,6 +5134,10 @@ cases:
       feature 'std'
         is required by 1 dependency:
           rand
+    crate 'tokio-rustls'
+      feature 'std'
+        is required by 1 dependency:
+          webpki
     crate 'tokio-stream'
       feature 'std'
         is required by 1 dependency:
@@ -4415,6 +5206,10 @@ cases:
           tracing
           tracing-core
           tracing-log
+    crate 'tracing-subscriber'
+      feature 'std'
+        must propagate to:
+          regex
     crate 'trie-bench'
       feature 'std'
         is required by 6 dependencies:
@@ -4451,12 +5246,11 @@ cases:
           tracing
     crate 'try-runtime-cli'
       feature 'std'
-        is required by 25 dependencies:
+        is required by 24 dependencies:
           clap
           frame-try-runtime
           hex
           log
-          node-primitives
           parity-scale-codec
           regex
           sc-executor
@@ -4507,12 +5301,6 @@ cases:
       feature 'std'
         must propagate to:
           subtle
-    crate 'url'
-      feature 'std'
-        is required by 3 dependencies:
-          form_urlencoded
-          idna
-          percent-encoding
     crate 'uuid'
       feature 'std'
         must propagate to:
@@ -4680,10 +5468,6 @@ cases:
       feature 'std'
         is required by 1 dependency:
           webpki
-    crate 'webpki-roots'
-      feature 'std'
-        is required by 1 dependency:
-          webpki (renamed from rustls-webpki)
     crate 'webrtc'
       feature 'std'
         is required by 10 dependencies:
@@ -4705,7 +5489,7 @@ cases:
           log
     crate 'webrtc-dtls'
       feature 'std'
-        is required by 22 dependencies:
+        is required by 23 dependencies:
           aes-gcm
           block-modes
           byteorder
@@ -4728,6 +5512,7 @@ cases:
           signature
           subtle
           webpki
+          x25519-dalek
     crate 'webrtc-ice'
       feature 'std'
         is required by 5 dependencies:
@@ -4790,9 +5575,8 @@ cases:
           zeroize
     crate 'x25519-dalek'
       feature 'std'
-        is required by 3 dependencies:
+        must propagate to:
           rand_core
-          serde
           zeroize
     crate 'x509-parser'
       feature 'std'
@@ -4836,7 +5620,7 @@ cases:
       feature 'std'
         is required by 1 dependency:
           zstd-safe
-    Found 1855 issues (run with --fix to fix).
+    Found 1830 issues (run with --fix to fix).
   code: 1
 - cmd: lint propagate-feature --feature std --workspace
   stdout: |
@@ -4845,9 +5629,13 @@ cases:
         is required by 2 dependencies:
           sp-core
           sp-keystore
+    crate 'frame-benchmarking'
+      feature 'std'
+        must propagate to:
+          frame-support-procedural
     crate 'frame-benchmarking-cli'
       feature 'std'
-        is required by 15 dependencies:
+        is required by 14 dependencies:
           frame-benchmarking
           frame-support
           frame-system
@@ -4856,13 +5644,12 @@ cases:
           sp-core
           sp-externalities
           sp-inherents
-          sp-io
           sp-keystore
           sp-runtime
           sp-state-machine
+          sp-std
           sp-storage
           sp-trie
-          sp-wasm-interface
     crate 'frame-election-provider-solution-type'
       feature 'std'
         is required by 3 dependencies:
@@ -4877,22 +5664,33 @@ cases:
           sp-arithmetic
           sp-npos-elections
           sp-runtime
+    crate 'frame-executive'
+      feature 'std'
+        must propagate to:
+          frame-try-runtime
     crate 'frame-remote-externalities'
       feature 'std'
         is required by 5 dependencies:
+          frame-support
+          pallet-elections-phragmen
           sp-core
           sp-io
           sp-runtime
-          sp-state-machine
-          sp-tracing
+    crate 'frame-support'
+      feature 'std'
+        must propagate to:
+          sp-debug-derive
+    crate 'frame-support-test'
+      feature 'std'
+        must propagate to:
+          test-pallet (renamed from frame-support-test-pallet)
     crate 'generate-bags'
       feature 'std'
-        is required by 5 dependencies:
+        is required by 4 dependencies:
           frame-election-provider-support
           frame-support
           frame-system
           pallet-staking
-          sp-staking
     crate 'mmr-gadget'
       feature 'std'
         is required by 6 dependencies:
@@ -4928,12 +5726,12 @@ cases:
           frame-system-rpc-runtime-api
           kitchensink-runtime
           node-primitives
-          pallet-asset-conversion-tx-payment
           pallet-asset-tx-payment
           pallet-assets
           pallet-balances
           pallet-im-online
           pallet-timestamp
+          pallet-transaction-payment
           sc-executor
           sp-api
           sp-authority-discovery
@@ -4944,9 +5742,9 @@ cases:
           sp-io
           sp-keystore
           sp-runtime
-          sp-statement-store
           sp-timestamp
           sp-tracing
+          sp-transaction-pool
           sp-transaction-storage-proof
     crate 'node-executor'
       feature 'std'
@@ -4978,7 +5776,8 @@ cases:
           sp-trie
     crate 'node-inspect'
       feature 'std'
-        is required by 2 dependencies:
+        is required by 3 dependencies:
+          sc-executor
           sp-core
           sp-runtime
     crate 'node-rpc'
@@ -5014,14 +5813,13 @@ cases:
           sp-timestamp
     crate 'node-testing'
       feature 'std'
-        is required by 15 dependencies:
+        is required by 14 dependencies:
           frame-system
           kitchensink-runtime
           node-primitives
-          pallet-asset-conversion
-          pallet-asset-conversion-tx-payment
           pallet-asset-tx-payment
           pallet-assets
+          pallet-transaction-payment
           sc-executor
           sp-api
           sp-block-builder
@@ -5030,6 +5828,14 @@ cases:
           sp-io
           sp-runtime
           sp-timestamp
+    crate 'pallet-asset-tx-payment'
+      feature 'std'
+        must propagate to:
+          sp-storage
+    crate 'pallet-aura'
+      feature 'std'
+        must propagate to:
+          sp-core
     crate 'pallet-bags-list-fuzzer'
       feature 'std'
         is required by 2 dependencies:
@@ -5048,6 +5854,18 @@ cases:
           sp-std
           sp-storage
           sp-tracing
+    crate 'pallet-contracts'
+      feature 'std'
+        must propagate to:
+          sp-api
+    crate 'pallet-contracts-primitives'
+      feature 'std'
+        must propagate to:
+          sp-weights
+    crate 'pallet-dev-mode'
+      feature 'std'
+        must propagate to:
+          sp-core
     crate 'pallet-election-provider-e2e-test'
       feature 'std'
         is required by 16 dependencies:
@@ -5067,6 +5885,18 @@ cases:
           sp-staking
           sp-std
           sp-tracing
+    crate 'pallet-example-basic'
+      feature 'std'
+        must propagate to:
+          sp-core
+    crate 'pallet-fast-unstake'
+      feature 'std'
+        must propagate to:
+          sp-core
+    crate 'pallet-nomination-pools-benchmarking'
+      feature 'std'
+        must propagate to:
+          pallet-balances
     crate 'pallet-nomination-pools-fuzzer'
       feature 'std'
         is required by 6 dependencies:
@@ -5093,12 +5923,22 @@ cases:
           sp-staking
           sp-std
           sp-tracing
-    crate 'pallet-paged-list-fuzzer'
+    crate 'pallet-root-offences'
       feature 'std'
-        is required by 3 dependencies:
-          frame-support
-          pallet-paged-list
+        must propagate to:
           sp-io
+          sp-staking
+          sp-std
+    crate 'pallet-root-testing'
+      feature 'std'
+        must propagate to:
+          sp-core
+          sp-io
+          sp-std
+    crate 'pallet-scheduler'
+      feature 'std'
+        must propagate to:
+          sp-core
     crate 'pallet-staking-reward-curve'
       feature 'std'
         is required by 1 dependency:
@@ -5111,6 +5951,14 @@ cases:
           sp-core
           sp-runtime
           sp-weights
+    crate 'pallet-transaction-storage'
+      feature 'std'
+        must propagate to:
+          sp-core
+    crate 'pallet-vesting'
+      feature 'std'
+        must propagate to:
+          sp-io
     crate 'sc-allocator'
       feature 'std'
         is required by 2 dependencies:
@@ -5158,11 +6006,12 @@ cases:
           sp-version
     crate 'sc-client-api'
       feature 'std'
-        is required by 10 dependencies:
+        is required by 11 dependencies:
           sc-executor
           sp-api
           sp-core
           sp-externalities
+          sp-keystore
           sp-runtime
           sp-state-machine
           sp-statement-store
@@ -5346,7 +6195,8 @@ cases:
           sp-runtime
     crate 'sc-network-statement'
       feature 'std'
-        is required by 1 dependency:
+        is required by 2 dependencies:
+          sp-runtime
           sp-statement-store
     crate 'sc-network-sync'
       feature 'std'
@@ -5359,7 +6209,8 @@ cases:
           sp-tracing
     crate 'sc-network-test'
       feature 'std'
-        is required by 4 dependencies:
+        is required by 5 dependencies:
+          sp-consensus-babe
           sp-core
           sp-runtime
           sp-tracing
@@ -5370,13 +6221,16 @@ cases:
           sp-runtime
     crate 'sc-offchain'
       feature 'std'
-        is required by 7 dependencies:
+        is required by 5 dependencies:
           sp-api
           sp-core
-          sp-externalities
-          sp-keystore
           sp-offchain
           sp-runtime
+          sp-tracing
+    crate 'sc-peerset'
+      feature 'std'
+        is required by 2 dependencies:
+          sp-arithmetic
           sp-tracing
     crate 'sc-rpc'
       feature 'std'
@@ -5404,6 +6258,10 @@ cases:
           sp-runtime
           sp-version
           substrate-test-runtime
+    crate 'sc-runtime-test'
+      feature 'std'
+        must propagate to:
+          sp-runtime-interface
     crate 'sc-service'
       feature 'std'
         is required by 14 dependencies:
@@ -5440,11 +6298,12 @@ cases:
           sp-core
     crate 'sc-statement-store'
       feature 'std'
-        is required by 4 dependencies:
+        is required by 5 dependencies:
           sp-api
           sp-core
           sp-runtime
           sp-statement-store
+          sp-tracing
     crate 'sc-storage-monitor'
       feature 'std'
         is required by 1 dependency:
@@ -5478,29 +6337,20 @@ cases:
           substrate-test-runtime
     crate 'sc-transaction-pool-api'
       feature 'std'
-        is required by 2 dependencies:
-          sp-core
+        is required by 1 dependency:
           sp-runtime
     crate 'sc-utils'
       feature 'std'
         is required by 1 dependency:
           sp-arithmetic
-    crate 'sp-api-test'
-      feature 'std'
-        is required by 6 dependencies:
-          sp-api
-          sp-core
-          sp-runtime
-          sp-state-machine
-          sp-tracing
-          sp-version
     crate 'sp-application-crypto-test'
       feature 'std'
-        is required by 4 dependencies:
+        is required by 5 dependencies:
           sp-api
           sp-application-crypto
           sp-core
           sp-keystore
+          sp-runtime
     crate 'sp-arithmetic-fuzzer'
       feature 'std'
         is required by 1 dependency:
@@ -5519,10 +6369,22 @@ cases:
           sp-runtime
           sp-state-machine
           sp-test-primitives
+    crate 'sp-consensus-babe'
+      feature 'std'
+        must propagate to:
+          sp-keystore
+    crate 'sp-consensus-grandpa'
+      feature 'std'
+        must propagate to:
+          sp-keystore
     crate 'sp-core-hashing-proc-macro'
       feature 'std'
         is required by 1 dependency:
           sp-core-hashing
+    crate 'sp-io'
+      feature 'std'
+        must propagate to:
+          sp-keystore
     crate 'sp-keyring'
       feature 'std'
         is required by 2 dependencies:
@@ -5547,15 +6409,14 @@ cases:
           sp-runtime-interface-test-wasm
           sp-runtime-interface-test-wasm-deprecated
           sp-state-machine
+    crate 'sp-statement-store'
+      feature 'std'
+        must propagate to:
+          sp-externalities
     crate 'sp-version-proc-macro'
       feature 'std'
         is required by 1 dependency:
           sp-version
-    crate 'substrate'
-      feature 'std'
-        is required by 2 dependencies:
-          frame-support
-          sp-runtime
     crate 'substrate-cli-test-utils'
       feature 'std'
         is required by 1 dependency:
@@ -5604,6 +6465,10 @@ cases:
           sp-keystore
           sp-runtime
           sp-state-machine
+    crate 'substrate-test-runtime'
+      feature 'std'
+        must propagate to:
+          frame-executive
     crate 'substrate-test-runtime-client'
       feature 'std'
         is required by 4 dependencies:
@@ -5617,9 +6482,8 @@ cases:
           sp-runtime
     crate 'try-runtime-cli'
       feature 'std'
-        is required by 18 dependencies:
+        is required by 17 dependencies:
           frame-try-runtime
-          node-primitives
           sc-executor
           sp-api
           sp-consensus-aura
@@ -5636,7 +6500,7 @@ cases:
           sp-transaction-storage-proof
           sp-version
           sp-weights
-    Found 514 issues (run with --fix to fix).
+    Found 531 issues (run with --fix to fix).
   code: 1
 - cmd: lint propagate-feature --feature try-runtime
   stdout: |
@@ -5660,20 +6524,47 @@ cases:
           frame-support
           frame-system
           sp-runtime
+    crate 'frame-benchmarking-pallet-pov'
+      feature 'try-runtime'
+        must propagate to:
+          sp-runtime
     crate 'frame-election-provider-solution-type'
       feature 'try-runtime'
         is required by 2 dependencies:
           frame-election-provider-support
           frame-support
+    crate 'frame-election-provider-support'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
     crate 'frame-election-solution-type-fuzzer'
       feature 'try-runtime'
         is required by 3 dependencies:
           frame-election-provider-support
           frame-support
           sp-runtime
+    crate 'frame-executive'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-transaction-payment
     crate 'frame-remote-externalities'
       feature 'try-runtime'
-        is required by 1 dependency:
+        is required by 3 dependencies:
+          frame-support
+          pallet-elections-phragmen
+          sp-runtime
+    crate 'frame-support'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'frame-support-test'
+      feature 'try-runtime'
+        must propagate to:
           sp-runtime
     crate 'frame-support-test-compile-pass'
       feature 'try-runtime'
@@ -5683,15 +6574,22 @@ cases:
           sp-runtime
     crate 'frame-support-test-pallet'
       feature 'try-runtime'
-        is required by 3 dependencies:
+        is required by 2 dependencies:
           frame-support
           frame-system
+    crate 'frame-system'
+      feature 'try-runtime'
+        must propagate to:
           sp-runtime
     crate 'frame-system-benchmarking'
       feature 'try-runtime'
         is required by 3 dependencies:
           frame-support
           frame-system
+          sp-runtime
+    crate 'frame-try-runtime'
+      feature 'try-runtime'
+        must propagate to:
           sp-runtime
     crate 'generate-bags'
       feature 'try-runtime'
@@ -5700,6 +6598,11 @@ cases:
           frame-support
           frame-system
           pallet-staking
+    crate 'kitchensink-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          sp-runtime
     crate 'mmr-gadget'
       feature 'try-runtime'
         is required by 1 dependency:
@@ -5712,6 +6615,17 @@ cases:
       feature 'try-runtime'
         is required by 2 dependencies:
           kitchensink-runtime
+          sp-runtime
+    crate 'node-cli'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-asset-tx-payment
+          pallet-assets
+          pallet-balances
+          pallet-im-online
+          pallet-timestamp
+          pallet-transaction-payment
           sp-runtime
     crate 'node-executor'
       feature 'try-runtime'
@@ -5735,7 +6649,8 @@ cases:
           sp-runtime
     crate 'node-primitives'
       feature 'try-runtime'
-        is required by 1 dependency:
+        is required by 2 dependencies:
+          frame-system
           sp-runtime
     crate 'node-rpc'
       feature 'try-runtime'
@@ -5745,15 +6660,91 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           kitchensink-runtime
+    crate 'node-template'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-transaction-payment
+          sp-runtime
+    crate 'node-template-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          sp-runtime
     crate 'node-testing'
       feature 'try-runtime'
-        is required by 7 dependencies:
+        is required by 6 dependencies:
           frame-system
           kitchensink-runtime
-          pallet-asset-conversion
-          pallet-asset-conversion-tx-payment
           pallet-asset-tx-payment
           pallet-assets
+          pallet-transaction-payment
+          sp-runtime
+    crate 'pallet-alliance'
+      feature 'try-runtime'
+        must propagate to:
+          pallet-balances
+          pallet-collective
+          pallet-identity
+          sp-runtime
+    crate 'pallet-asset-rate'
+      feature 'try-runtime'
+        must propagate to:
+          pallet-balances
+    crate 'pallet-asset-tx-payment'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-assets
+          pallet-authorship
+          pallet-balances
+          pallet-transaction-payment
+          sp-runtime
+    crate 'pallet-assets'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-atomic-swap'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-aura'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-authority-discovery'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-session
+          sp-runtime
+    crate 'pallet-authorship'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-babe'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-authorship
+          pallet-balances
+          pallet-offences
+          pallet-session
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-bags-list'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
           sp-runtime
     crate 'pallet-bags-list-fuzzer'
       feature 'try-runtime'
@@ -5769,9 +6760,91 @@ cases:
           pallet-bags-list
           pallet-staking
           sp-runtime
+    crate 'pallet-balances'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-transaction-payment
+          sp-runtime
+    crate 'pallet-beefy'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-authorship
+          pallet-balances
+          pallet-offences
+          pallet-session
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-beefy-mmr'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-beefy
+          pallet-mmr
+          pallet-session
+          sp-runtime
+    crate 'pallet-bounties'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-child-bounties'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-bounties
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-collective'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-contracts'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-insecure-randomness-collective-flip
+          pallet-proxy
+          pallet-timestamp
+          pallet-utility
+          sp-runtime
     crate 'pallet-contracts-primitives'
       feature 'try-runtime'
         is required by 1 dependency:
+          sp-runtime
+    crate 'pallet-conviction-voting'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-scheduler
+          sp-runtime
+    crate 'pallet-core-fellowship'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-democracy'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-preimage
+          pallet-scheduler
+          sp-runtime
+    crate 'pallet-dev-mode'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
           sp-runtime
     crate 'pallet-election-provider-e2e-test'
       feature 'try-runtime'
@@ -5786,17 +6859,157 @@ cases:
           pallet-staking
           pallet-timestamp
           sp-runtime
+    crate 'pallet-election-provider-multi-phase'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-election-provider-support-benchmarking'
       feature 'try-runtime'
         is required by 3 dependencies:
           frame-election-provider-support
           frame-system
           sp-runtime
+    crate 'pallet-elections-phragmen'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-example-basic'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-example-offchain-worker'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-fast-unstake'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-balances
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-glutton'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-grandpa'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-authorship
+          pallet-balances
+          pallet-offences
+          pallet-session
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-identity'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-im-online'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-authorship
+          pallet-session
+          sp-runtime
+    crate 'pallet-indices'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-insecure-randomness-collective-flip'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-lottery'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support-test
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-membership'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-message-queue'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-mmr'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-multisig'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-nft-fractionalization'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-assets
+          pallet-balances
+          pallet-nfts
+          sp-runtime
+    crate 'pallet-nfts'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-nfts-runtime-api'
       feature 'try-runtime'
         is required by 2 dependencies:
           frame-support
           pallet-nfts
+    crate 'pallet-nicks'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-nis'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-node-authorization'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-nomination-pools'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-nomination-pools-benchmarking'
       feature 'try-runtime'
         is required by 9 dependencies:
@@ -5832,6 +7045,12 @@ cases:
           pallet-staking
           pallet-timestamp
           sp-runtime
+    crate 'pallet-offences'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-offences-benchmarking'
       feature 'try-runtime'
         is required by 12 dependencies:
@@ -5847,11 +7066,81 @@ cases:
           pallet-staking
           pallet-timestamp
           sp-runtime
-    crate 'pallet-paged-list-fuzzer'
+    crate 'pallet-preimage'
       feature 'try-runtime'
-        is required by 2 dependencies:
-          frame-support
-          pallet-paged-list
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-proxy'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-utility
+          sp-runtime
+    crate 'pallet-ranked-collective'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-recovery'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-referenda'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-preimage
+          pallet-scheduler
+          sp-runtime
+    crate 'pallet-remark'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-root-offences'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-balances
+          pallet-session
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-root-testing'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-salary'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-scheduler'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-preimage
+          sp-runtime
+    crate 'pallet-scored-pool'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-session'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-timestamp
+          sp-runtime
     crate 'pallet-session-benchmarking'
       feature 'try-runtime'
         is required by 8 dependencies:
@@ -5863,9 +7152,66 @@ cases:
           pallet-staking
           pallet-timestamp
           sp-runtime
+    crate 'pallet-society'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support-test
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-staking'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-authorship
+          pallet-bags-list
+          pallet-balances
+          pallet-session
+          pallet-timestamp
+          sp-runtime
     crate 'pallet-staking-reward-curve'
       feature 'try-runtime'
         is required by 1 dependency:
+          sp-runtime
+    crate 'pallet-state-trie-migration'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-statement'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-sudo'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-template'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-timestamp'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-tips'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-transaction-payment'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
           sp-runtime
     crate 'pallet-transaction-payment-rpc'
       feature 'try-runtime'
@@ -5875,6 +7221,47 @@ cases:
       feature 'try-runtime'
         is required by 2 dependencies:
           pallet-transaction-payment
+          sp-runtime
+    crate 'pallet-transaction-storage'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-treasury'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-utility
+          sp-runtime
+    crate 'pallet-uniques'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-utility'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-collective
+          pallet-root-testing
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-vesting'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-whitelist'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-preimage
           sp-runtime
     crate 'sc-authority-discovery'
       feature 'try-runtime'
@@ -5981,6 +7368,10 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
+    crate 'sc-network-statement'
+      feature 'try-runtime'
+        is required by 1 dependency:
+          sp-runtime
     crate 'sc-network-sync'
       feature 'try-runtime'
         is required by 1 dependency:
@@ -6053,6 +7444,10 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
+    crate 'sp-application-crypto-test'
+      feature 'try-runtime'
+        is required by 1 dependency:
+          sp-runtime
     crate 'sp-authority-discovery'
       feature 'try-runtime'
         is required by 1 dependency:
@@ -6086,10 +7481,6 @@ cases:
         is required by 1 dependency:
           sp-runtime
     crate 'sp-consensus-pow'
-      feature 'try-runtime'
-        is required by 1 dependency:
-          sp-runtime
-    crate 'sp-genesis-builder'
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
@@ -6161,12 +7552,6 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
-    crate 'substrate'
-      feature 'try-runtime'
-        is required by 3 dependencies:
-          frame-support
-          node-cli
-          sp-runtime
     crate 'substrate-frame-cli'
       feature 'try-runtime'
         is required by 3 dependencies:
@@ -6197,12 +7582,15 @@ cases:
           sp-runtime
     crate 'substrate-test-runtime'
       feature 'try-runtime'
-        is required by 7 dependencies:
+        is required by 10 dependencies:
           frame-executive
           frame-support
           frame-system
           pallet-babe
           pallet-balances
+          pallet-beefy-mmr
+          pallet-root-testing
+          pallet-sudo
           pallet-timestamp
           sp-runtime
     crate 'substrate-test-runtime-client'
@@ -6213,7 +7601,11 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
-    Found 222 issues (run with --fix to fix).
+    crate 'try-runtime-cli'
+      feature 'try-runtime'
+        must propagate to:
+          sp-runtime
+    Found 504 issues (run with --fix to fix).
   code: 1
 - cmd: lint propagate-feature --feature try-runtime --workspace
   stdout: |
@@ -6237,20 +7629,47 @@ cases:
           frame-support
           frame-system
           sp-runtime
+    crate 'frame-benchmarking-pallet-pov'
+      feature 'try-runtime'
+        must propagate to:
+          sp-runtime
     crate 'frame-election-provider-solution-type'
       feature 'try-runtime'
         is required by 2 dependencies:
           frame-election-provider-support
           frame-support
+    crate 'frame-election-provider-support'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support
+          frame-system
+          sp-runtime
     crate 'frame-election-solution-type-fuzzer'
       feature 'try-runtime'
         is required by 3 dependencies:
           frame-election-provider-support
           frame-support
           sp-runtime
+    crate 'frame-executive'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-transaction-payment
     crate 'frame-remote-externalities'
       feature 'try-runtime'
-        is required by 1 dependency:
+        is required by 3 dependencies:
+          frame-support
+          pallet-elections-phragmen
+          sp-runtime
+    crate 'frame-support'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'frame-support-test'
+      feature 'try-runtime'
+        must propagate to:
           sp-runtime
     crate 'frame-support-test-compile-pass'
       feature 'try-runtime'
@@ -6260,15 +7679,22 @@ cases:
           sp-runtime
     crate 'frame-support-test-pallet'
       feature 'try-runtime'
-        is required by 3 dependencies:
+        is required by 2 dependencies:
           frame-support
           frame-system
+    crate 'frame-system'
+      feature 'try-runtime'
+        must propagate to:
           sp-runtime
     crate 'frame-system-benchmarking'
       feature 'try-runtime'
         is required by 3 dependencies:
           frame-support
           frame-system
+          sp-runtime
+    crate 'frame-try-runtime'
+      feature 'try-runtime'
+        must propagate to:
           sp-runtime
     crate 'generate-bags'
       feature 'try-runtime'
@@ -6277,6 +7703,11 @@ cases:
           frame-support
           frame-system
           pallet-staking
+    crate 'kitchensink-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          sp-runtime
     crate 'mmr-gadget'
       feature 'try-runtime'
         is required by 1 dependency:
@@ -6289,6 +7720,17 @@ cases:
       feature 'try-runtime'
         is required by 2 dependencies:
           kitchensink-runtime
+          sp-runtime
+    crate 'node-cli'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-asset-tx-payment
+          pallet-assets
+          pallet-balances
+          pallet-im-online
+          pallet-timestamp
+          pallet-transaction-payment
           sp-runtime
     crate 'node-executor'
       feature 'try-runtime'
@@ -6312,7 +7754,8 @@ cases:
           sp-runtime
     crate 'node-primitives'
       feature 'try-runtime'
-        is required by 1 dependency:
+        is required by 2 dependencies:
+          frame-system
           sp-runtime
     crate 'node-rpc'
       feature 'try-runtime'
@@ -6322,15 +7765,91 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           kitchensink-runtime
+    crate 'node-template'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-transaction-payment
+          sp-runtime
+    crate 'node-template-runtime'
+      feature 'try-runtime'
+        must propagate to:
+          sp-runtime
     crate 'node-testing'
       feature 'try-runtime'
-        is required by 7 dependencies:
+        is required by 6 dependencies:
           frame-system
           kitchensink-runtime
-          pallet-asset-conversion
-          pallet-asset-conversion-tx-payment
           pallet-asset-tx-payment
           pallet-assets
+          pallet-transaction-payment
+          sp-runtime
+    crate 'pallet-alliance'
+      feature 'try-runtime'
+        must propagate to:
+          pallet-balances
+          pallet-collective
+          pallet-identity
+          sp-runtime
+    crate 'pallet-asset-rate'
+      feature 'try-runtime'
+        must propagate to:
+          pallet-balances
+    crate 'pallet-asset-tx-payment'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-assets
+          pallet-authorship
+          pallet-balances
+          pallet-transaction-payment
+          sp-runtime
+    crate 'pallet-assets'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-atomic-swap'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-aura'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-authority-discovery'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-session
+          sp-runtime
+    crate 'pallet-authorship'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-babe'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-authorship
+          pallet-balances
+          pallet-offences
+          pallet-session
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-bags-list'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
           sp-runtime
     crate 'pallet-bags-list-fuzzer'
       feature 'try-runtime'
@@ -6346,9 +7865,91 @@ cases:
           pallet-bags-list
           pallet-staking
           sp-runtime
+    crate 'pallet-balances'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-transaction-payment
+          sp-runtime
+    crate 'pallet-beefy'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-authorship
+          pallet-balances
+          pallet-offences
+          pallet-session
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-beefy-mmr'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-beefy
+          pallet-mmr
+          pallet-session
+          sp-runtime
+    crate 'pallet-bounties'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-child-bounties'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-bounties
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-collective'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-contracts'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-insecure-randomness-collective-flip
+          pallet-proxy
+          pallet-timestamp
+          pallet-utility
+          sp-runtime
     crate 'pallet-contracts-primitives'
       feature 'try-runtime'
         is required by 1 dependency:
+          sp-runtime
+    crate 'pallet-conviction-voting'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-scheduler
+          sp-runtime
+    crate 'pallet-core-fellowship'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-democracy'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-preimage
+          pallet-scheduler
+          sp-runtime
+    crate 'pallet-dev-mode'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
           sp-runtime
     crate 'pallet-election-provider-e2e-test'
       feature 'try-runtime'
@@ -6363,17 +7964,157 @@ cases:
           pallet-staking
           pallet-timestamp
           sp-runtime
+    crate 'pallet-election-provider-multi-phase'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-election-provider-support-benchmarking'
       feature 'try-runtime'
         is required by 3 dependencies:
           frame-election-provider-support
           frame-system
           sp-runtime
+    crate 'pallet-elections-phragmen'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-example-basic'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-example-offchain-worker'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-fast-unstake'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-balances
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-glutton'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-grandpa'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-authorship
+          pallet-balances
+          pallet-offences
+          pallet-session
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-identity'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-im-online'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-authorship
+          pallet-session
+          sp-runtime
+    crate 'pallet-indices'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-insecure-randomness-collective-flip'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-lottery'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support-test
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-membership'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-message-queue'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-mmr'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-multisig'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-nft-fractionalization'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-assets
+          pallet-balances
+          pallet-nfts
+          sp-runtime
+    crate 'pallet-nfts'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-nfts-runtime-api'
       feature 'try-runtime'
         is required by 2 dependencies:
           frame-support
           pallet-nfts
+    crate 'pallet-nicks'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-nis'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-node-authorization'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-nomination-pools'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-nomination-pools-benchmarking'
       feature 'try-runtime'
         is required by 9 dependencies:
@@ -6409,6 +8150,12 @@ cases:
           pallet-staking
           pallet-timestamp
           sp-runtime
+    crate 'pallet-offences'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
     crate 'pallet-offences-benchmarking'
       feature 'try-runtime'
         is required by 12 dependencies:
@@ -6424,11 +8171,81 @@ cases:
           pallet-staking
           pallet-timestamp
           sp-runtime
-    crate 'pallet-paged-list-fuzzer'
+    crate 'pallet-preimage'
       feature 'try-runtime'
-        is required by 2 dependencies:
-          frame-support
-          pallet-paged-list
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-proxy'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-utility
+          sp-runtime
+    crate 'pallet-ranked-collective'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-recovery'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-referenda'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-preimage
+          pallet-scheduler
+          sp-runtime
+    crate 'pallet-remark'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-root-offences'
+      feature 'try-runtime'
+        must propagate to:
+          frame-election-provider-support
+          frame-system
+          pallet-balances
+          pallet-session
+          pallet-staking
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-root-testing'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-salary'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-scheduler'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-preimage
+          sp-runtime
+    crate 'pallet-scored-pool'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-session'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-timestamp
+          sp-runtime
     crate 'pallet-session-benchmarking'
       feature 'try-runtime'
         is required by 8 dependencies:
@@ -6440,9 +8257,66 @@ cases:
           pallet-staking
           pallet-timestamp
           sp-runtime
+    crate 'pallet-society'
+      feature 'try-runtime'
+        must propagate to:
+          frame-support-test
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-staking'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-authorship
+          pallet-bags-list
+          pallet-balances
+          pallet-session
+          pallet-timestamp
+          sp-runtime
     crate 'pallet-staking-reward-curve'
       feature 'try-runtime'
         is required by 1 dependency:
+          sp-runtime
+    crate 'pallet-state-trie-migration'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-statement'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-sudo'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-template'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-timestamp'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          sp-runtime
+    crate 'pallet-tips'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-treasury
+          sp-runtime
+    crate 'pallet-transaction-payment'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
           sp-runtime
     crate 'pallet-transaction-payment-rpc'
       feature 'try-runtime'
@@ -6452,6 +8326,47 @@ cases:
       feature 'try-runtime'
         is required by 2 dependencies:
           pallet-transaction-payment
+          sp-runtime
+    crate 'pallet-transaction-storage'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-treasury'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-utility
+          sp-runtime
+    crate 'pallet-uniques'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-utility'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-collective
+          pallet-root-testing
+          pallet-timestamp
+          sp-runtime
+    crate 'pallet-vesting'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          sp-runtime
+    crate 'pallet-whitelist'
+      feature 'try-runtime'
+        must propagate to:
+          frame-system
+          pallet-balances
+          pallet-preimage
           sp-runtime
     crate 'sc-authority-discovery'
       feature 'try-runtime'
@@ -6558,6 +8473,10 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
+    crate 'sc-network-statement'
+      feature 'try-runtime'
+        is required by 1 dependency:
+          sp-runtime
     crate 'sc-network-sync'
       feature 'try-runtime'
         is required by 1 dependency:
@@ -6630,6 +8549,10 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
+    crate 'sp-application-crypto-test'
+      feature 'try-runtime'
+        is required by 1 dependency:
+          sp-runtime
     crate 'sp-authority-discovery'
       feature 'try-runtime'
         is required by 1 dependency:
@@ -6663,10 +8586,6 @@ cases:
         is required by 1 dependency:
           sp-runtime
     crate 'sp-consensus-pow'
-      feature 'try-runtime'
-        is required by 1 dependency:
-          sp-runtime
-    crate 'sp-genesis-builder'
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
@@ -6738,12 +8657,6 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
-    crate 'substrate'
-      feature 'try-runtime'
-        is required by 3 dependencies:
-          frame-support
-          node-cli
-          sp-runtime
     crate 'substrate-frame-cli'
       feature 'try-runtime'
         is required by 3 dependencies:
@@ -6774,12 +8687,15 @@ cases:
           sp-runtime
     crate 'substrate-test-runtime'
       feature 'try-runtime'
-        is required by 7 dependencies:
+        is required by 10 dependencies:
           frame-executive
           frame-support
           frame-system
           pallet-babe
           pallet-balances
+          pallet-beefy-mmr
+          pallet-root-testing
+          pallet-sudo
           pallet-timestamp
           sp-runtime
     crate 'substrate-test-runtime-client'
@@ -6790,5 +8706,9 @@ cases:
       feature 'try-runtime'
         is required by 1 dependency:
           sp-runtime
-    Found 222 issues (run with --fix to fix).
+    crate 'try-runtime-cli'
+      feature 'try-runtime'
+        must propagate to:
+          sp-runtime
+    Found 504 issues (run with --fix to fix).
   code: 1

--- a/tests/ui/root-args/version.yaml
+++ b/tests/ui/root-args/version.yaml
@@ -2,7 +2,7 @@ crates: []
 cases:
 - cmd: --version
   stdout: |
-    zepter 0.11.0
+    zepter 0.11.1
 - cmd: -V
   stdout: |
-    zepter 0.11.0
+    zepter 0.11.1


### PR DESCRIPTION
Needed for https://github.com/paritytech/polkadot-sdk/pull/1194

Changes to `lint propagate-features`:
- If a crate `A` depends on a crate `B` and enables its default features, then now all features of `B` that are transitively enabled by its default feature will also count as being enabled. Note that it only considers features that `B` enables on itself. It could also check for transitive dependencies in the form of `B/G -> C/F -> B/F` but it will only allow paths that consist solely of `B/*` to keep things simple.