### PR TITLE
Remove deps and better error messages

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Install MSRV
       run: cargo install cargo-msrv --locked -q
     - name: Verify MSRV
-      run: cargo msrv verify
+      run: cargo msrv verify -- cargo install --locked --path .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,7 +1504,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zepter"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bstr"
@@ -520,9 +520,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -553,9 +553,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -592,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -622,15 +622,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -650,9 +650,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -955,11 +955,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1113,13 +1113,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -1177,9 +1176,9 @@ checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1489,9 +1488,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.18"
+version = "0.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
 ]
@@ -1515,7 +1514,7 @@ dependencies = [
  "env_logger",
  "glob",
  "histo",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "lazy_static",
  "log",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zepter"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = [ "Oliver Tale-Yazdi" ]
 description = "Analyze, Fix and Format features in your Rust workspace."
@@ -25,19 +25,18 @@ clap = { version = "4.4.18", features = ["derive", "cargo"] }
 colour = { version = "0.7.0", optional = true }
 criterion = { version = "0.5", optional = true }
 env_logger = { version = "0.10.2", features = [ "auto-color", "humantime" ], optional = true }
-histo = "1.0.0"
+histo = { version = "1.0.0", optional = true }
 itertools = "0.12.0"
 log = { version = "0.4.20", optional = true }
 semver = "1"
 serde = "1.0.196"
-serde_json = "1.0.113"
+serde_json = { version = "1.0.113", optional = true }
 serde_yaml = "0.9.31"
 tempfile = { version = "3.9.0", optional = true }
 toml_edit = "0.21.0"
 tracing = { version = "0.1.40", optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.79"
 glob = "0.3.1"
 lazy_static = "1.4.0"
 pretty_assertions = "1.4.0"
@@ -48,11 +47,10 @@ zepter = { path = ".", features = ["testing"] }
 
 [features]
 default = [ "logging" ]
-
 logging = [ "dep:env_logger", "dep:log" ]
-benchmarking = [ "dep:criterion" ]
-
-testing = [ "dep:anyhow", "dep:assert_cmd", "dep:colour", "dep:tempfile" ]
+benchmarking = [ "dep:criterion", "dep:serde_json" ]
+testing = [ "dep:anyhow", "dep:assert_cmd", "dep:colour", "dep:tempfile", "dep:serde_json" ]
+debugging = [ "dep:histo" ]
 
 [profile.dev]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ colour = { version = "0.7.0", optional = true }
 criterion = { version = "0.5", optional = true }
 env_logger = { version = "0.10.2", features = [ "auto-color", "humantime" ], optional = true }
 histo = { version = "1.0.0", optional = true }
-itertools = "0.12.0"
+itertools = "0.12.1"
 log = { version = "0.4.20", optional = true }
 semver = "1"
 serde = "1.0.196"
 serde_json = { version = "1.0.113", optional = true }
 serde_yaml = "0.9.31"
-tempfile = { version = "3.9.0", optional = true }
-toml_edit = "0.21.0"
+tempfile = { version = "3.10.0", optional = true }
+toml_edit = "0.22.4"
 tracing = { version = "0.1.40", optional = true }
 
 [dev-dependencies]

--- a/src/autofix.rs
+++ b/src/autofix.rs
@@ -466,7 +466,6 @@ impl AutoFixer {
 
 			let dep = deps.get_mut(dname).unwrap();
 			Self::lift_some_dependency(dep, default_feats)?;
-			//deps.key_decor_mut(dname).unwrap().set_suffix("");
 		}
 		Ok(())
 	}

--- a/src/cmd/debug.rs
+++ b/src/cmd/debug.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // SPDX-FileCopyrightText: Oliver Tale-Yazdi <oliver@tasty.limo>
 
+#![cfg(feature = "debugging")]
+
 use super::{lint::CrateAndFeature, GlobalArgs};
 use crate::{cmd::lint::build_feature_dag, prelude::Dag};
 

--- a/src/cmd/lint.rs
+++ b/src/cmd/lint.rs
@@ -253,13 +253,13 @@ impl core::str::FromStr for IgnoreSetting {
 }
 
 impl LintCmd {
-	pub(crate) fn run(&self, global: &GlobalArgs) {
+	pub(crate) fn run(&self, global: &GlobalArgs) -> Result<(), String> {
 		match &self.subcommand {
 			SubCommand::PropagateFeature(cmd) => cmd.run(global),
-			SubCommand::NeverEnables(cmd) => cmd.run(global),
-			SubCommand::NeverImplies(cmd) => cmd.run(global),
-			SubCommand::WhyEnabled(cmd) => cmd.run(global),
-			SubCommand::OnlyEnables(cmd) => cmd.run(global),
+			SubCommand::NeverEnables(cmd) => Ok(cmd.run(global)),
+			SubCommand::NeverImplies(cmd) => Ok(cmd.run(global)),
+			SubCommand::WhyEnabled(cmd) => Ok(cmd.run(global)),
+			SubCommand::OnlyEnables(cmd) => Ok(cmd.run(global)),
 		}
 	}
 }
@@ -402,13 +402,15 @@ impl NeverEnablesCmd {
 }
 
 impl PropagateFeatureCmd {
-	pub fn run(&self, global: &GlobalArgs) {
-		let meta = self.cargo_args.load_metadata().expect("Loads metadata");
+	pub fn run(&self, global: &GlobalArgs) -> Result<(), String> {
+		let meta = self.cargo_args.load_metadata()?;
 		let dag = build_feature_dag(&meta, &meta.packages);
 
 		for feature in self.features.iter() {
 			self.run_feature(&meta, &dag, feature.clone(), global);
 		}
+
+		Ok(())
 	}
 
 	fn run_feature(

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -70,6 +70,7 @@ enum SubCommand {
 	Run(run::RunCmd),
 	#[clap(hide = true)]
 	Transpose(transpose::TransposeCmd),
+	#[cfg(feature = "debugging")]
 	Debug(debug::DebugCmd),
 }
 
@@ -106,6 +107,7 @@ impl Command {
 				cmd.run(&self.global);
 				Ok(())
 			},
+			#[cfg(feature = "debugging")]
 			Some(SubCommand::Debug(cmd)) => {
 				cmd.run(&self.global);
 				Ok(())
@@ -205,9 +207,6 @@ pub struct CargoArgs {
 
 	#[clap(long, global = true)]
 	pub all_features: bool,
-
-	#[clap(long = "debug-keep-meta")]
-	pub keep_meta: Option<std::path::PathBuf>,
 }
 
 impl CargoArgs {
@@ -240,14 +239,7 @@ impl CargoArgs {
 			cmd.other_options(vec!["--locked".to_string()]);
 		}
 
-		let meta = cmd.exec().map_err(|e| format!("Failed to load metadata: {e}"))?;
-
-		if let Some(path) = &self.keep_meta {
-			std::fs::write(path, serde_json::to_string_pretty(&meta).unwrap()).unwrap();
-			log::info!("Wrote metadata to {}", path.display());
-		}
-
-		Ok(meta)
+		cmd.exec().map_err(|e| format!("Failed to load metadata: {e}"))
 	}
 }
 

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -133,11 +133,9 @@ impl LiftToWorkspaceCmd {
 
 		if self.exact_version.is_some() && self.version_resolver != VersionResolveMode::Exact {
 			return Err("Cannot use --exact-version without --version-resolver=exact".to_string())
-		}
+		};
 
-		let mut args = self.cargo_args.clone();
-		args.workspace = true;
-		let meta = args.load_metadata()?;
+		let meta = self.cargo_args.clone().with_workspace(true).load_metadata()?;
 		log::debug!("Scanning workspace for '{}'", self.dependency);
 		// version -> crate
 		let mut by_version = HashMap::<semver::VersionReq, Vec<(Package, Dep)>>::new();
@@ -305,9 +303,7 @@ impl StripDevDepsCmd {
 	pub fn run(&self, g: &GlobalArgs) {
 		g.warn_unstable();
 
-		let mut args = self.cargo_args.clone();
-		args.workspace = true;
-		let meta = self.cargo_args.load_metadata().expect("Loads metadata");
+		let meta = self.cargo_args.clone().with_workspace(true).load_metadata().expect("Loads metadata");
 		let kind = DependencyKind::Development;
 		// Allowed dir that we can write to.
 		let allowed_dir = canonicalize(meta.workspace_root.as_std_path()).unwrap();

--- a/src/cmd/transpose.rs
+++ b/src/cmd/transpose.rs
@@ -240,7 +240,7 @@ impl LiftToWorkspaceCmd {
 		fixer.add_workspace_dep(&dep, false)?;
 
 		let mut modified = 0;
-		for (pkg, fixer) in fixers.values_mut() {
+		for (_pkg, fixer) in fixers.values_mut() {
 			if !fixer.modified() {
 				continue
 			}
@@ -249,7 +249,7 @@ impl LiftToWorkspaceCmd {
 			if self.fix {
 				fixer.save()?;
 			} else {
-				log::debug!("Would modify {:?}", pkg.name);
+				log::debug!("Would modify {:?}", _pkg.name);
 			}
 		}
 		if fixer.modified() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@
 pub mod semver;
 pub mod workflow;
 
-use crate::{config::workflow::WorkflowFile, log};
+use crate::{config::workflow::WorkflowFile, log, ErrToStr};
 
 use std::{
 	fs::canonicalize,
@@ -86,7 +86,7 @@ impl ConfigArgs {
 
 	fn locate_config(&self) -> Result<PathBuf, String> {
 		if let Some(path) = &self.config {
-			let path = canonicalize(path).expect("Must canonicalize path");
+			let path = canonicalize(path).err_to_str()?;
 
 			if path.exists() {
 				Ok(path)
@@ -111,23 +111,16 @@ impl ConfigArgs {
 
 	fn locate_workspace(&self) -> Result<PathBuf, String> {
 		let mut cmd = std::process::Command::new("cargo");
-		cmd.arg("locate-project").args(["--workspace", "--offline", "--locked"]);
+		cmd.arg("locate-project").args(["--message-format", "plain", "--workspace", "--offline", "--locked"]);
 		if let Some(path) = &self.manifest_path {
 			cmd.arg("--manifest-path").arg(path);
 		}
-		let output = cmd.output().expect("Failed to run `cargo locate-project`");
+		let output = cmd.output().err_to_str()?;
 		let path = output.stdout;
 		let path =
-			String::from_utf8(path).expect("Failed to parse output of `cargo locate-project`");
-		let path: serde_json::Value = serde_json::from_str(&path).unwrap_or_else(|_| {
-			panic!(
-				"Failed to parse output of `cargo locate-project`: '{}'",
-				String::from_utf8_lossy(&output.stderr)
-			)
-		});
-		let path = path["root"].as_str().expect("Failed to parse output of `cargo locate-project`");
+			String::from_utf8(path).err_to_str()?;
 		let path = PathBuf::from(path);
-		let root = path.parent().expect("Failed to get parent of workspace root");
+		let root = path.parent().ok_or("Failed to find workspace root")?;
 
 		Ok(root.into())
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,3 +79,14 @@ macro_rules! trace {
 		}
 	};
 }
+
+/// Convert the error or a `Result` into a `String` error.
+pub(crate) trait ErrToStr<R> {
+	fn err_to_str(self) -> Result<R, String>;
+}
+
+impl<R, E: std::fmt::Display> ErrToStr<R> for Result<R, E> {
+	fn err_to_str(self) -> Result<R, String> {
+		self.map_err(|e| format!("{}", e))
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@
 use clap::Parser;
 use zepter::cmd::Command;
 
-fn main() -> Result<(), String> {
+fn main() -> Result<(), ()> {
 	setup_logging();
 
 	// Need to remove this in case `cargo-zepter` is used:
@@ -17,7 +17,7 @@ fn main() -> Result<(), String> {
 
 	if let Err(err) = Command::parse_from(args).run() {
 		eprintln!("{}", err);
-		Err("see log".into())
+		Err(())
 	} else {
 		Ok(())
 	}


### PR DESCRIPTION
Changes:
- Print a dedicated error msg when the `Cargo.lock` needs an update
- Remove direct `serde_json` dep (indirect stays)
- Fix msrv check