### PR TITLE
Warn on unexpected libstd dependence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -19,9 +19,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bitflags"
@@ -100,15 +100,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bstr"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "camino"
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
 ]
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "futures"
@@ -481,9 +481,9 @@ checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -522,9 +522,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "half"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -544,9 +544,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "histo"
@@ -565,9 +565,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -604,15 +604,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -653,9 +653,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "mio"
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "relative-path"
@@ -910,9 +910,9 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "rstest"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+checksum = "9d5316d2a1479eeef1ea21e7f9ddc67c191d497abc8fc3ba2467857abbb68330"
 dependencies = [
  "futures",
  "futures-timer",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
 dependencies = [
  "cfg-if",
  "glob",
@@ -948,11 +948,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -1074,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "streaming-stats"
@@ -1089,15 +1089,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1124,18 +1124,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1229,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -1245,9 +1245,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1255,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -1270,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1293,15 +1293,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1353,7 +1353,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -1373,17 +1373,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -1394,9 +1394,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1406,9 +1406,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1418,9 +1418,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1430,9 +1430,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1442,9 +1442,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1454,9 +1454,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1466,15 +1466,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.6.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zepter"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zepter"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 authors = [ "Oliver Tale-Yazdi" ]
 description = "Analyze, Fix and Format features in your Rust workspace."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ glob = "0.3.1"
 lazy_static = "1.4.0"
 pretty_assertions = "1.4.0"
 rand = "0.8.5"
-rstest = "0.18.2"
+rstest = "0.19.0"
 serde = "1.0.197"
 zepter = { path = ".", features = ["testing"] }
 

--- a/src/cmd/lint/nostd.rs
+++ b/src/cmd/lint/nostd.rs
@@ -112,7 +112,11 @@ impl DefaultFeaturesDisabledCmd {
 		}
 	}
 
-	fn supports_nostd(g: &GlobalArgs, krate: &Package, cache: &mut BTreeMap<String, bool>) -> Result<bool, String> {
+	fn supports_nostd(
+		g: &GlobalArgs,
+		krate: &Package,
+		cache: &mut BTreeMap<String, bool>,
+	) -> Result<bool, String> {
 		log::debug!("Checking if crate supports no-std: {}", krate.name);
 		if let Some(res) = cache.get(krate.manifest_path.as_str()) {
 			return Ok(*res)
@@ -135,7 +139,11 @@ impl DefaultFeaturesDisabledCmd {
 			content.contains("#![no_std]")
 		{
 			if content.contains("#![cfg(") {
-				println!("{}: Crate may unexpectedly pull in libstd: {}", g.yellow("WARN"), krate.name);
+				println!(
+					"{}: Crate may unexpectedly pull in libstd: {}",
+					g.yellow("WARN"),
+					krate.name
+				);
 			}
 			log::debug!("Crate supports no-std: {} (path={})", krate.name, krate.manifest_path);
 			true

--- a/tests/integration/sdk/nostd.yaml
+++ b/tests/integration/sdk/nostd.yaml
@@ -5,8 +5,15 @@ cases:
 - cmd: lint no-std default-features-of-nostd-dependencies-disabled
   stdout: |
     Default features not disabled for dependency: sp-core -> sp-externalities
+    WARN: Crate may unexpectedly pull in libstd: frame-try-runtime
+    WARN: Crate may unexpectedly pull in libstd: frame-benchmarking
     Default features not disabled for dependency: sp-session -> sp-runtime
     Default features not disabled for dependency: sp-consensus-babe -> sp-timestamp
+    WARN: Crate may unexpectedly pull in libstd: frame-system-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: pallet-election-provider-support-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: pallet-nomination-pools-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: pallet-offences-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: pallet-session-benchmarking
     Default features not disabled for dependency: pallet-contracts -> pallet-contracts-proc-macro
     Default features not disabled for dependency: pallet-nomination-pools -> pallet-balances
     Default features not disabled for dependency: pallet-nomination-pools -> sp-tracing
@@ -16,6 +23,8 @@ cases:
     Default features not disabled for dependency: cumulus-primitives-parachain-inherent -> sp-runtime
     Default features not disabled for dependency: cumulus-primitives-parachain-inherent -> sp-state-machine
     Default features not disabled for dependency: cumulus-primitives-parachain-inherent -> sp-storage
+    WARN: Crate may unexpectedly pull in libstd: cumulus-pallet-session-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: xcm-executor-integration-tests
     Default features not disabled for dependency: xcm-executor-integration-tests -> frame-system
     Default features not disabled for dependency: xcm-executor-integration-tests -> pallet-xcm
     Default features not disabled for dependency: xcm-executor-integration-tests -> polkadot-test-runtime
@@ -31,8 +40,15 @@ cases:
 - cmd: lint no-std default-features-of-nostd-dependencies-disabled --fix
   stdout: |
     Default features not disabled for dependency: sp-core -> sp-externalities
+    WARN: Crate may unexpectedly pull in libstd: frame-try-runtime
+    WARN: Crate may unexpectedly pull in libstd: frame-benchmarking
     Default features not disabled for dependency: sp-session -> sp-runtime
     Default features not disabled for dependency: sp-consensus-babe -> sp-timestamp
+    WARN: Crate may unexpectedly pull in libstd: frame-system-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: pallet-election-provider-support-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: pallet-nomination-pools-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: pallet-offences-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: pallet-session-benchmarking
     Default features not disabled for dependency: pallet-contracts -> pallet-contracts-proc-macro
     Default features not disabled for dependency: pallet-nomination-pools -> pallet-balances
     Default features not disabled for dependency: pallet-nomination-pools -> sp-tracing
@@ -42,6 +58,8 @@ cases:
     Default features not disabled for dependency: cumulus-primitives-parachain-inherent -> sp-runtime
     Default features not disabled for dependency: cumulus-primitives-parachain-inherent -> sp-state-machine
     Default features not disabled for dependency: cumulus-primitives-parachain-inherent -> sp-storage
+    WARN: Crate may unexpectedly pull in libstd: cumulus-pallet-session-benchmarking
+    WARN: Crate may unexpectedly pull in libstd: xcm-executor-integration-tests
     Default features not disabled for dependency: xcm-executor-integration-tests -> frame-system
     Default features not disabled for dependency: xcm-executor-integration-tests -> pallet-xcm
     Default features not disabled for dependency: xcm-executor-integration-tests -> polkadot-test-runtime

--- a/tests/ui/config/v1/basic.yaml
+++ b/tests/ui/config/v1/basic.yaml
@@ -3,25 +3,25 @@ crates:
 cases:
 - cmd: run default
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
 - cmd: run
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
 - cmd: ''
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
 - cmd: run my_version
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'my_version'
     [INFO] 1/1 --version
@@ -36,7 +36,7 @@ cases:
     [INFO] 1/1 debug --no-benchmark
 - cmd: run both
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
     Num workspace members: 1
     Num dependencies: 1
     DAG nodes: 0, links: 0

--- a/tests/ui/config/v1/finds_all.yaml
+++ b/tests/ui/config/v1/finds_all.yaml
@@ -3,7 +3,7 @@ crates:
 cases:
 - cmd: ''
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -19,7 +19,7 @@ cases:
           - [ '--version' ]
 - cmd: ''
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -35,7 +35,7 @@ cases:
           - [ '--version' ]
 - cmd: ''
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -51,7 +51,7 @@ cases:
           - [ '--version' ]
 - cmd: run default
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -67,7 +67,7 @@ cases:
           - [ '--version' ]
 - cmd: run default
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -83,7 +83,7 @@ cases:
           - [ '--version' ]
 - cmd: run default
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -99,7 +99,7 @@ cases:
           - [ '--version' ]
 - cmd: run default --config .cargo/polkadot.yaml
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -115,7 +115,7 @@ cases:
           - [ '--version' ]
 - cmd: run default -c .cargo/polkadot.yaml
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version

--- a/tests/ui/config/v1/version_bin.yaml
+++ b/tests/ui/config/v1/version_bin.yaml
@@ -4,7 +4,7 @@ cases:
 - cmd: run default
   stderr: |
     thread 'main' panicked at src/cmd/run.rs:27:46:
-    Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.4.0. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
+    Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.4.1. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
   code: 101
 - cmd: run default --check-cfg-compatibility=off
@@ -13,7 +13,7 @@ cases:
   stderr: |
     [INFO] Running workflow 'default'
     thread 'main' panicked at src/cmd/run.rs:27:46:
-    Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.4.0. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
+    Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.4.1. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
   code: 1
 configs:

--- a/tests/ui/root-args/version.yaml
+++ b/tests/ui/root-args/version.yaml
@@ -2,7 +2,7 @@ crates: []
 cases:
 - cmd: --version
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1
 - cmd: -V
   stdout: |
-    zepter 1.4.0
+    zepter 1.4.1


### PR DESCRIPTION
Warn when a crate could unexpectedly pull in libstd.

Example on Polkadot-SDK:
![Screenshot 2024-04-09 at 23 19 24](https://github.com/ggwpez/zepter/assets/10380170/2a8783d5-43a4-4257-b6f9-84e7fe5988a1)

Since these crate do have both:
`#![cfg_attr(not(feature = "std"), no_std)]` **and** `#![cfg(feature = "runtime-benchmarks")]` which conditionally disables the nostd attribute.

Note that this is just a warning for now. Could be made into an additional lint (plus failure condition) in the future.