### PR TITLE
Support Rust 1.78 - 1.85.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -44,7 +44,6 @@ rustflags = [
     "-Wclippy::match_wild_err_arm",
     "-Wclippy::match_wildcard_for_single_variants",
     "-Wclippy::mem_forget",
-    "-Wclippy::mismatched_target_os",
     "-Wclippy::missing_enforced_import_renames",
     "-Wclippy::mut_mut",
     "-Wclippy::mutex_integer",

--- a/.github/workflows/downstream_legacy.yml
+++ b/.github/workflows/downstream_legacy.yml
@@ -29,6 +29,8 @@ jobs:
       with:
         repository: paritytech/${{ matrix.repo }}
         fetch-depth: 1
+
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     
     - name: Cargo install
       run: cargo install --git ${{ github.server_url }}/${{ github.repository }} zepter --rev $GITHUB_SHA --locked -q

--- a/.github/workflows/downstream_nightly.yml
+++ b/.github/workflows/downstream_nightly.yml
@@ -32,6 +32,8 @@ jobs:
       with:
         repository: ${{ matrix.repo }}
         fetch-depth: 1
+
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     
     - name: Install
       run: cargo install zepter --version '${{ matrix.version }}' -f --locked -q --no-default-features

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - name: Cargo install
         run: cargo install --path . --locked -q
       

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install MSRV
       run: cargo install cargo-msrv --locked -q
     - name: Verify MSRV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,4 +39,4 @@ jobs:
         cargo clippy --all-targets --no-default-features -q
 
     - name: Format
-      run: cargo fmt --check
+      run: cargo +nightly fmt --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
 
     - name: Build
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -739,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -987,9 +987,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1017,18 +1017,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zepter"
-version = "1.5.1"
+version = "1.78.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,43 +34,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "assert_cmd"
@@ -90,21 +91,21 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bstr"
-version = "1.9.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -113,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "camino"
@@ -128,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -190,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -200,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -212,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -224,15 +225,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colour"
@@ -281,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -300,15 +301,15 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "diff"
@@ -330,15 +331,15 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -346,92 +347,50 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
-
-[[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -439,16 +398,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
-
-[[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -458,17 +411,13 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -476,26 +425,27 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
+ "r-efi",
  "wasi",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -503,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -515,9 +465,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "histo"
@@ -529,16 +479,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -546,20 +490,20 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -572,25 +516,50 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f33145a5cbea837164362c7bd596106eb7c5198f97d1ba6f6ebb3223952e488"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ce13c40ec6956157a3635d97a1ee2df323b263f09ea14165131289cb0f5c19"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -602,21 +571,21 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -635,21 +604,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -659,9 +628,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -672,30 +641,48 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
+name = "portable-atomic"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
-version = "3.1.0"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
@@ -704,15 +691,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -730,11 +717,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -748,29 +735,35 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
+ "zerocopy",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -778,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
@@ -807,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -819,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -842,21 +835,21 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b423f0e62bdd61734b67cd21ff50871dfaeb9cc74f869dcd6af974fbcb19936"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
  "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e1711e7d14f74b12a58411c542185ef7fb7f2e7f8ee6e2940a883628522b42"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
 dependencies = [
  "cfg-if",
  "glob",
@@ -872,31 +865,37 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustversion"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -909,27 +908,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -938,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -998,22 +997,22 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "termtree"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1047,37 +1046,26 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278f3d518e152219c994ce877758516bca5e118eaed6996192a774fb9fbf0788"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.6.13",
+ "winnow",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1086,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1097,18 +1085,18 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1124,9 +1112,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -1143,29 +1131,33 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1174,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1184,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1197,15 +1189,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1229,11 +1224,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1241,15 +1236,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1326,20 +1312,20 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winnow"
-version = "0.6.13"
+name = "wit-bindgen-rt"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "memchr",
+ "bitflags",
 ]
 
 [[package]]
@@ -1362,7 +1348,7 @@ dependencies = [
  "env_logger",
  "glob",
  "histo",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "log",
  "pretty_assertions",
@@ -1374,7 +1360,27 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "toml_edit 0.22.16",
+ "toml_edit",
  "tracing",
  "zepter",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zepter"
-version = "1.5.1"
+version = "1.78.0"
 edition = "2021"
 authors = [ "Oliver Tale-Yazdi" ]
 description = "Analyze, Fix and Format features in your Rust workspace."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Analyze, Fix and Format features in your Rust workspace."
 license = "GPL-3.0-only"
 repository = "https://github.com/ggwpez/zepter"
 # Update the README if you change this:
-rust-version = "1.78"
+rust-version = "1.74"
 
 [[bin]]
 name = "zepter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ required-features = [ "benchmarking" ]
 anyhow = { version = "1.0.89", optional = true }
 assert_cmd = { version = "2.0.16", optional = true }
 camino = "1.1.9"
-cargo_metadata = "0.18.1"
+cargo_metadata = "0.19.2"
 clap = { version = "4.5.13", features = ["derive", "cargo"] }
 colour = { version = "2.1.0", optional = true }
 criterion = { version = "0.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,33 +18,33 @@ harness = false
 required-features = [ "benchmarking" ]
 
 [dependencies]
-anyhow = { version = "1.0.89", optional = true }
+anyhow = { version = "1.0.97", optional = true }
 assert_cmd = { version = "2.0.16", optional = true }
 camino = "1.1.9"
 cargo_metadata = "0.19.2"
-clap = { version = "4.5.13", features = ["derive", "cargo"] }
+clap = { version = "4.5.35", features = ["derive", "cargo"] }
 colour = { version = "2.1.0", optional = true }
 criterion = { version = "0.5", optional = true }
-env_logger = { version = "0.11.5", features = [ "auto-color", "humantime" ], optional = true }
+env_logger = { version = "0.11.8", features = [ "auto-color", "humantime" ], optional = true }
 histo = { version = "1.0.0", optional = true }
-itertools = "0.13.0"
-log = { version = "0.4.22", optional = true }
-regex = "1.11.0"
+itertools = "0.14.0"
+log = { version = "0.4.27", optional = true }
+regex = "1.11.1"
 semver = "1"
-serde = "1.0.210"
-serde_json = { version = "1.0.128", optional = true }
+serde = "1.0.219"
+serde_json = { version = "1.0.140", optional = true }
 serde_yaml = "0.9.34"
-tempfile = { version = "3.13.0", optional = true }
-toml_edit = "0.22.16"
-tracing = { version = "0.1.40", optional = true }
+tempfile = { version = "3.19.1", optional = true }
+toml_edit = "0.22.24"
+tracing = { version = "0.1.41", optional = true }
 
 [dev-dependencies]
-glob = "0.3.1"
+glob = "0.3.2"
 lazy_static = "1.5.0"
 pretty_assertions = "1.4.1"
-rand = "0.8.5"
-rstest = "0.22.0"
-serde = "1.0.210"
+rand = "0.9.0"
+rstest = "0.25.0"
+serde = "1.0.219"
 zepter = { path = ".", features = ["testing"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Analyze, Fix and Format features in your Rust workspace."
 license = "GPL-3.0-only"
 repository = "https://github.com/ggwpez/zepter"
 # Update the README if you change this:
-rust-version = "1.74"
+rust-version = "1.78"
 
 [[bin]]
 name = "zepter"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ update some dependencies by pulling them up. To get around this and actually do 
 zepter transpose dependency lift-to-workspace "regex:^serde.*" --ignore-errors --fix --version-resolver=highest
 ```
 
-This will try to select the "highest" SemVer version of each crate.
+This will try to select the "highest" `SemVer` version of each crate.
 
 ## Example - Feature Formatting
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Rust](https://github.com/ggwpez/zepter/actions/workflows/rust.yml/badge.svg)](https://github.com/ggwpez/zepter/actions/workflows/rust.yml)
 [![crates.io](https://img.shields.io/crates/v/zepter.svg)](https://crates.io/crates/zepter)
-![MSRV](https://img.shields.io/badge/MSRV-1.74-informational)
+![MSRV](https://img.shields.io/badge/MSRV-1.78-informational)
 [![docs.rs](https://img.shields.io/docsrs/zepter)](https://docs.rs/zepter/latest/zepter)
 
 Analyze, Fix and Format features in your Rust workspace. The goal of this tool is to have this CI ready to prevent common errors with Rust features.

--- a/benches/dag.rs
+++ b/benches/dag.rs
@@ -13,8 +13,8 @@ fn build_dag(nodes: usize, edges: usize) -> Dag<usize> {
 		dag.add_node(i);
 	}
 	for _ in 0..edges {
-		let from = rng.gen_range(0..nodes);
-		let to = rng.gen_range(0..nodes);
+		let from = rng.random_range(0..nodes);
+		let to = rng.random_range(0..nodes);
 		dag.add_edge(from, to);
 	}
 	dag

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.85.1"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77"
+channel = "1.78"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-01-10"
+channel = "nightly-2024-10-17"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78"
+channel = "stable"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-10-17"
+channel = "1.77"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"

--- a/src/autofix.rs
+++ b/src/autofix.rs
@@ -10,8 +10,9 @@ use crate::{
 use cargo_metadata::{Dependency, DependencyKind};
 use std::{
 	collections::BTreeMap as Map,
+	fmt,
+	fmt::Display,
 	path::{Path, PathBuf},
-	fmt, fmt::Display,
 };
 use toml_edit::{table, value, Array, DocumentMut, Formatted, InlineTable, Item, Table, Value};
 

--- a/src/autofix.rs
+++ b/src/autofix.rs
@@ -11,6 +11,7 @@ use cargo_metadata::{Dependency, DependencyKind};
 use std::{
 	collections::BTreeMap as Map,
 	path::{Path, PathBuf},
+	fmt, fmt::Display,
 };
 use toml_edit::{table, value, Array, DocumentMut, Formatted, InlineTable, Item, Table, Value};
 
@@ -408,7 +409,7 @@ impl AutoFixer {
 		let mut new_vals = Vec::new();
 
 		for mut value in values {
-			if value.as_str().map_or(false, |s| s.is_empty()) {
+			if value.as_str().is_some_and(|s| s.is_empty()) {
 				panic!("Empty value in feature");
 			}
 			let mut prefix: String = match value.decor().prefix() {
@@ -468,7 +469,7 @@ impl AutoFixer {
 			log::warn!("No '{}' entry found", kind);
 			return Ok(())
 		}
-		let deps: &mut Table = doc[&kind].as_table_mut().unwrap();
+		let deps: &mut Table = doc[kind].as_table_mut().unwrap();
 
 		if !deps.contains_key(dname) {
 			return Ok(())
@@ -747,9 +748,9 @@ impl AutoFixer {
 	}
 }
 
-impl ToString for AutoFixer {
-	fn to_string(&self) -> String {
-		self.doc.as_ref().unwrap().to_string()
+impl Display for AutoFixer {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}", self.doc.as_ref().unwrap())
 	}
 }
 

--- a/src/cmd/lint.rs
+++ b/src/cmd/lint.rs
@@ -315,10 +315,10 @@ impl NeverImpliesCmd {
 
 				// TODO cleanup this cluster fuck
 				let lookup = |id: &str| {
+					let referenced_crate = pkgs.iter().find(|pkg| pkg.id.to_string() == id).unwrap();
 					pkgs.iter()
 						.find(|pkg| {
-							pkg.id.to_string().split(' ').next().unwrap() ==
-								id.split(' ').next().unwrap()
+							pkg.id == referenced_crate.id
 						})
 						.unwrap_or_else(|| panic!("Could not find crate '{id}' in the metadata."))
 				};
@@ -396,10 +396,11 @@ impl NeverEnablesCmd {
 		}
 
 		for (lhs, rhss) in offenders {
-			// TODO hack
+			// Find by id
+			let lhs = pkgs.iter().find(|p| p.id.to_string() == lhs).unwrap();
 			println!(
 				"crate {:?}\n  feature {:?}",
-				lhs.split(' ').next().unwrap(),
+				lhs.name,
 				self.precondition
 			);
 			// TODO support multiple left/right side features.
@@ -524,10 +525,12 @@ impl PropagateFeatureCmd {
 
 				if let Some((_, lhs_ignore)) = ignore_missing_propagate
 					.iter()
-					.find(|(c, _)| pkg.id.repr.starts_with(&format!("{} ", c.0)) && c.1 == feature)
+					.find(|(c, _)| {
+						pkg.name == c.0 && c.1 == feature
+					})
 				{
 					if lhs_ignore.iter().any(|i| {
-						dep.pkg.id.repr.starts_with(&format!("{} ", i.0)) && i.1 == feature
+						dep.pkg.name == i.0 && i.1 == feature
 					}) {
 						continue
 					}

--- a/src/cmd/lint.rs
+++ b/src/cmd/lint.rs
@@ -484,7 +484,7 @@ impl PropagateFeatureCmd {
 				if !dep.pkg.features.contains_key(&feature) {
 					continue
 				}
-				if pkg.features.get(&feature).is_none() {
+				if !pkg.features.contains_key(&feature) {
 					if self.left_side_feature_missing != MuteSetting::Ignore {
 						feature_missing.entry(pkg.id.to_string()).or_default().insert(dep);
 					}
@@ -607,7 +607,7 @@ impl PropagateFeatureCmd {
 						let non_optional = self
 							.feature_enables_dep
 							.as_ref()
-							.map_or(false, |v| v.contains(&(feature.clone(), dep_name.clone())));
+							.is_some_and(|v| v.contains(&(feature.clone(), dep_name.clone())));
 						let opt = if !non_optional && dep.optional { "?" } else { "" };
 
 						fixer

--- a/src/cmd/lint.rs
+++ b/src/cmd/lint.rs
@@ -315,11 +315,10 @@ impl NeverImpliesCmd {
 
 				// TODO cleanup this cluster fuck
 				let lookup = |id: &str| {
-					let referenced_crate = pkgs.iter().find(|pkg| pkg.id.to_string() == id).unwrap();
+					let referenced_crate =
+						pkgs.iter().find(|pkg| pkg.id.to_string() == id).unwrap();
 					pkgs.iter()
-						.find(|pkg| {
-							pkg.id == referenced_crate.id
-						})
+						.find(|pkg| pkg.id == referenced_crate.id)
 						.unwrap_or_else(|| panic!("Could not find crate '{id}' in the metadata."))
 				};
 
@@ -398,11 +397,7 @@ impl NeverEnablesCmd {
 		for (lhs, rhss) in offenders {
 			// Find by id
 			let lhs = pkgs.iter().find(|p| p.id.to_string() == lhs).unwrap();
-			println!(
-				"crate {:?}\n  feature {:?}",
-				lhs.name,
-				self.precondition
-			);
+			println!("crate {:?}\n  feature {:?}", lhs.name, self.precondition);
 			// TODO support multiple left/right side features.
 			println!("    enables feature {:?} on dependencies:", self.stays_disabled);
 
@@ -523,15 +518,10 @@ impl PropagateFeatureCmd {
 					continue
 				}
 
-				if let Some((_, lhs_ignore)) = ignore_missing_propagate
-					.iter()
-					.find(|(c, _)| {
-						pkg.name == c.0 && c.1 == feature
-					})
+				if let Some((_, lhs_ignore)) =
+					ignore_missing_propagate.iter().find(|(c, _)| pkg.name == c.0 && c.1 == feature)
 				{
-					if lhs_ignore.iter().any(|i| {
-						dep.pkg.name == i.0 && i.1 == feature
-					}) {
+					if lhs_ignore.iter().any(|i| dep.pkg.name == i.0 && i.1 == feature) {
 						continue
 					}
 				}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -370,7 +370,7 @@ pub(crate) fn check_can_modify<P: AsRef<Path>>(root: P, modify: P) -> Result<boo
 	let modify = canonicalize(modify).err_to_str()?;
 
 	if !modify.starts_with(&root) {
-		format!(
+		println!(
 			"Path is outside of the workspace: {:?} (not in {:?})",
 			modify.display(),
 			root.display()

--- a/src/cmd/transpose/lift_to_workspace.rs
+++ b/src/cmd/transpose/lift_to_workspace.rs
@@ -105,6 +105,7 @@ impl LiftToWorkspaceCmd {
 			match self.run_for_dependency(g, &meta, dep, &mut fixers) {
 				Ok(()) => (),
 				Err(e) if self.ignore_errors => {
+					let _ = e;
 					log::error!("Failed to lift up '{}': {}", dep, e);
 				},
 				Err(e) => return Err(format!("Failed to lift up '{}': {}", dep, e)),

--- a/src/cmd/transpose/lift_to_workspace.rs
+++ b/src/cmd/transpose/lift_to_workspace.rs
@@ -227,7 +227,7 @@ impl LiftToWorkspaceCmd {
 			if let Some(rename) = &maybe_rename {
 				assert_eq!(rename, dep_name);
 			}
-			let ref location = source_location;
+			let location = &source_location;
 
 			if dep.uses_default_features != workspace_default_features_enabled {
 				fixer.lift_dependency(

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -150,7 +150,7 @@ where
 	///
 	/// *Directly* means with via an edge.
 	pub fn adjacent(&self, from: &T, to: &T) -> bool {
-		self.edges.get(from).map_or(false, |v| v.contains(to))
+		self.edges.get(from).is_some_and(|v| v.contains(to))
 	}
 
 	/// Whether `from` is reachable to `to` via.

--- a/src/mock/git.rs
+++ b/src/mock/git.rs
@@ -108,7 +108,7 @@ pub fn clone_repo(repo: &str, rev: &str) -> Result<PathBuf, anyhow::Error> {
 		cmd.arg("remote");
 		cmd.arg("add");
 		cmd.arg("origin");
-		cmd.arg(&format!("https://github.com/{}", repo));
+		cmd.arg(format!("https://github.com/{}", repo));
 		cmd.assert().try_success()?;
 
 		fetch(&dir, rev)?;

--- a/tests/integration/sdk/workflows.yaml
+++ b/tests/integration/sdk/workflows.yaml
@@ -5,6 +5,8 @@ cases:
 - cmd: run check
   stderr: |
     [INFO] Running workflow 'check'
+    [INFO] 1/2 lint propagate-feature
+    [INFO] 2/2 format features
   code: 0
 - cmd: run default
   stderr: |

--- a/tests/integration/sdk/workflows.yaml
+++ b/tests/integration/sdk/workflows.yaml
@@ -3,38 +3,13 @@ repo:
   ref: c86b633695299ed27053940d5ea5c5a2392964b3
 cases:
 - cmd: run check
-  stdout: |
-    crate 'sp-core' (/Users/vados/Documents/work/zepter/target/test-repos/paritytech/polkadot-sdk/substrate/primitives/core/Cargo.toml)
-      feature 'std'
-        must propagate to:
-          bandersnatch_vrfs
-    Found 1 issue.
-    Error: Command 'lint propagate-feature' failed with exit code 1
-
-    Polkadot-SDK uses the Zepter CLI to detect abnormalities in the feature configuration.
-    It looks like one more more checks failed; please check the console output. You can try to automatically address them by running `zepter`.
-    Otherwise please ask directly in the Merge Request, GitHub Discussions or on Matrix Chat, thank you.
-
-    For more information, see:
-      - https://github.com/paritytech/polkadot-sdk/issues/1831
-      - https://github.com/ggwpez/zepter
   stderr: |
     [INFO] Running workflow 'check'
-  code: 1
+  code: 0
 - cmd: run default
-  stdout: |
-    crate 'sp-core' (/Users/vados/Documents/work/zepter/target/test-repos/paritytech/polkadot-sdk/substrate/primitives/core/Cargo.toml)
-      feature 'std'
-        must propagate to:
-          bandersnatch_vrfs
-    Found 1 issue and fixed 1 (all fixed).
-    Found 1 crate with unformatted features:
-      sp-core
-    Formatted 1 crate (all fixed).
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/2 lint propagate-feature
     [INFO] 2/2 format features
   code: 0
-  diff: "diff --git substrate/primitives/core/Cargo.toml substrate/primitives/core/Cargo.toml\nindex 1b6b10eeee..c09916e389 100644\n--- substrate/primitives/core/Cargo.toml\n+++ substrate/primitives/core/Cargo.toml\n@@ -78,0 +79 @@ std = [\n+\t\"bandersnatch_vrfs?/std\",\n"
 no_default_args: true

--- a/tests/integration/sdk/workflows.yaml
+++ b/tests/integration/sdk/workflows.yaml
@@ -3,13 +3,38 @@ repo:
   ref: c86b633695299ed27053940d5ea5c5a2392964b3
 cases:
 - cmd: run check
+  stdout: |
+    crate 'sp-core' (/Users/vados/Documents/work/zepter/target/test-repos/paritytech/polkadot-sdk/substrate/primitives/core/Cargo.toml)
+      feature 'std'
+        must propagate to:
+          bandersnatch_vrfs
+    Found 1 issue.
+    Error: Command 'lint propagate-feature' failed with exit code 1
+
+    Polkadot-SDK uses the Zepter CLI to detect abnormalities in the feature configuration.
+    It looks like one more more checks failed; please check the console output. You can try to automatically address them by running `zepter`.
+    Otherwise please ask directly in the Merge Request, GitHub Discussions or on Matrix Chat, thank you.
+
+    For more information, see:
+      - https://github.com/paritytech/polkadot-sdk/issues/1831
+      - https://github.com/ggwpez/zepter
   stderr: |
     [INFO] Running workflow 'check'
-    [INFO] 1/2 lint propagate-feature
-    [INFO] 2/2 format features
+  code: 1
 - cmd: run default
+  stdout: |
+    crate 'sp-core' (/Users/vados/Documents/work/zepter/target/test-repos/paritytech/polkadot-sdk/substrate/primitives/core/Cargo.toml)
+      feature 'std'
+        must propagate to:
+          bandersnatch_vrfs
+    Found 1 issue and fixed 1 (all fixed).
+    Found 1 crate with unformatted features:
+      sp-core
+    Formatted 1 crate (all fixed).
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/2 lint propagate-feature
     [INFO] 2/2 format features
+  code: 0
+  diff: "diff --git substrate/primitives/core/Cargo.toml substrate/primitives/core/Cargo.toml\nindex 1b6b10eeee..c09916e389 100644\n--- substrate/primitives/core/Cargo.toml\n+++ substrate/primitives/core/Cargo.toml\n@@ -78,0 +79 @@ std = [\n+\t\"bandersnatch_vrfs?/std\",\n"
 no_default_args: true

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,6 +9,9 @@ use zepter::mock::*;
 #[test]
 #[ignore]
 fn integration() {
+	// Set backtrace since it appears in the UI test output
+	std::env::set_var("RUST_BACKTRACE", "0");
+
 	let filter = std::env::var("UI_FILTER").unwrap_or_else(|_| "**/*.yaml".into());
 	let regex = format!("tests/{}", filter);
 	// Loop through all files in tests/ recursively

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -174,7 +174,7 @@ fn integration() {
 		}
 	}
 	if failed == 0 && good == 0 {
-		panic!("No tests found");
+		panic!("No tests found. Try something like '**/never-enables/diamond.yaml'");
 	}
 	println!();
 }

--- a/tests/ui/config/v1/basic.yaml
+++ b/tests/ui/config/v1/basic.yaml
@@ -3,25 +3,25 @@ crates:
 cases:
 - cmd: run default
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
 - cmd: run
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
 - cmd: ''
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
 - cmd: run my_version
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'my_version'
     [INFO] 1/1 --version
@@ -36,7 +36,7 @@ cases:
     [INFO] 1/1 debug --no-benchmark
 - cmd: run both
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
     Num workspace members: 1
     Num dependencies: 1
     DAG nodes: 0, links: 0

--- a/tests/ui/config/v1/finds_all.yaml
+++ b/tests/ui/config/v1/finds_all.yaml
@@ -3,7 +3,7 @@ crates:
 cases:
 - cmd: ''
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -19,7 +19,7 @@ cases:
           - [ '--version' ]
 - cmd: ''
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -35,7 +35,7 @@ cases:
           - [ '--version' ]
 - cmd: ''
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -51,7 +51,7 @@ cases:
           - [ '--version' ]
 - cmd: run default
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -67,7 +67,7 @@ cases:
           - [ '--version' ]
 - cmd: run default
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -83,7 +83,7 @@ cases:
           - [ '--version' ]
 - cmd: run default
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -99,7 +99,7 @@ cases:
           - [ '--version' ]
 - cmd: run default --config .cargo/polkadot.yaml
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version
@@ -115,7 +115,7 @@ cases:
           - [ '--version' ]
 - cmd: run default -c .cargo/polkadot.yaml
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
   stderr: |
     [INFO] Running workflow 'default'
     [INFO] 1/1 --version

--- a/tests/ui/config/v1/format.yaml
+++ b/tests/ui/config/v1/format.yaml
@@ -23,7 +23,7 @@ cases:
     [INFO] 1/1 f f
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index abe9319f17..1368faef82 100644
+    index eba55cd80c..8849621452 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
     @@ -15,4 +15 @@ B = { version = "*", path = "../B"}
@@ -33,10 +33,10 @@ cases:
     -]
     +F0 = [ "B/F0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index e52ef09a77..53767a7726 100644
+    index 195f3af664..4f68eee744 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -14,2 +14 @@ edition = "2021"
+    @@ -14,2 +14 @@ edition = "2024"
     -F0 = [
     -]
     +F0 = []
@@ -60,7 +60,7 @@ cases:
     [INFO] 1/1 f f
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index abe9319f17..1368faef82 100644
+    index eba55cd80c..8849621452 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
     @@ -15,4 +15 @@ B = { version = "*", path = "../B"}
@@ -70,10 +70,10 @@ cases:
     -]
     +F0 = [ "B/F0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index e52ef09a77..53767a7726 100644
+    index 195f3af664..4f68eee744 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -14,2 +14 @@ edition = "2021"
+    @@ -14,2 +14 @@ edition = "2024"
     -F0 = [
     -]
     +F0 = []

--- a/tests/ui/config/v1/format.yaml
+++ b/tests/ui/config/v1/format.yaml
@@ -23,20 +23,20 @@ cases:
     [INFO] 1/1 f f
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index 78c5769bd7..8a27508a42 100644
+    index abe9319f17..1368faef82 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
-    @@ -17,4 +17 @@ B = { version = "*", path = "../B"}
+    @@ -15,4 +15 @@ B = { version = "*", path = "../B"}
     -F0 = [
     -"B/F0",
     -"B/F0",
     -]
     +F0 = [ "B/F0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index 3fa22af3e1..db61ce3b2d 100644
+    index e52ef09a77..53767a7726 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -16,2 +16 @@ edition = "2021"
+    @@ -14,2 +14 @@ edition = "2021"
     -F0 = [
     -]
     +F0 = []
@@ -60,20 +60,20 @@ cases:
     [INFO] 1/1 f f
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index 78c5769bd7..8a27508a42 100644
+    index abe9319f17..1368faef82 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
-    @@ -17,4 +17 @@ B = { version = "*", path = "../B"}
+    @@ -15,4 +15 @@ B = { version = "*", path = "../B"}
     -F0 = [
     -"B/F0",
     -"B/F0",
     -]
     +F0 = [ "B/F0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index 3fa22af3e1..db61ce3b2d 100644
+    index e52ef09a77..53767a7726 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -16,2 +16 @@ edition = "2021"
+    @@ -14,2 +14 @@ edition = "2021"
     -F0 = [
     -]
     +F0 = []

--- a/tests/ui/config/v1/version_bin.yaml
+++ b/tests/ui/config/v1/version_bin.yaml
@@ -2,7 +2,8 @@ crates:
 - name: A
 cases:
 - cmd: run default
-  stderr: |
+  stderr: |2
+
     thread 'main' panicked at src/cmd/run.rs:27:46:
     Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.5.1. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
@@ -12,6 +13,7 @@ cases:
     Error: Command '' failed with exit code 101
   stderr: |
     [INFO] Running workflow 'default'
+
     thread 'main' panicked at src/cmd/run.rs:27:46:
     Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.5.1. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/config/v1/version_bin.yaml
+++ b/tests/ui/config/v1/version_bin.yaml
@@ -5,7 +5,7 @@ cases:
   stderr: |2
 
     thread 'main' panicked at src/cmd/run.rs:27:46:
-    Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.5.1. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
+    Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.78.0. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
   code: 101
 - cmd: run default --check-cfg-compatibility=off
@@ -15,7 +15,7 @@ cases:
     [INFO] Running workflow 'default'
 
     thread 'main' panicked at src/cmd/run.rs:27:46:
-    Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.5.1. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
+    Invalid config file: "Config file version is too new. The file requires at least version 2.0.0, but the current version is 1.78.0. Please update Zepter or ignore this check with `--check-cfg-compatibility=off`."
     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
   code: 1
 configs:

--- a/tests/ui/config/v1/version_file.yaml
+++ b/tests/ui/config/v1/version_file.yaml
@@ -2,7 +2,8 @@ crates:
 - name: A
 cases:
 - cmd: run default
-  stderr: |
+  stderr: |2
+
     thread 'main' panicked at src/cmd/run.rs:27:46:
     Invalid config file: "Can only parse workflow files with version '1'"
     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/ui/fmt/check.yaml
+++ b/tests/ui/fmt/check.yaml
@@ -52,7 +52,7 @@ cases:
     Formatted 3 crates (all fixed).
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index 5b6b2a98ad..cf40203c54 100644
+    index c4ef250c25..b4d04dede9 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
     @@ -16,8 +16,2 @@ C = { version = "*", path = "../C"}
@@ -67,10 +67,10 @@ cases:
     +F0 = [ "B/F0", "C/F0" ]
     +G0 = [ "B/G0", "C/G0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index b1f73da9de..9f0724ae5f 100644
+    index 168330edee..62d91ff0e0 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -14,4 +14,2 @@ edition = "2021"
+    @@ -14,4 +14,2 @@ edition = "2024"
     -F0 = [
     -]
     -G0 = [
@@ -78,10 +78,10 @@ cases:
     +F0 = []
     +G0 = []
     diff --git C/Cargo.toml C/Cargo.toml
-    index 4340ea8ca3..01b8fc2540 100644
+    index 96ff11808e..ee8de9f46c 100644
     --- C/Cargo.toml
     +++ C/Cargo.toml
-    @@ -14,4 +14,2 @@ edition = "2021"
+    @@ -14,4 +14,2 @@ edition = "2024"
     -F0 = [
     -]
     -G0 = [
@@ -98,7 +98,7 @@ cases:
   code: 0
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index 5b6b2a98ad..cf40203c54 100644
+    index c4ef250c25..b4d04dede9 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
     @@ -16,8 +16,2 @@ C = { version = "*", path = "../C"}
@@ -113,10 +113,10 @@ cases:
     +F0 = [ "B/F0", "C/F0" ]
     +G0 = [ "B/G0", "C/G0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index b1f73da9de..9f0724ae5f 100644
+    index 168330edee..62d91ff0e0 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -14,4 +14,2 @@ edition = "2021"
+    @@ -14,4 +14,2 @@ edition = "2024"
     -F0 = [
     -]
     -G0 = [
@@ -124,10 +124,10 @@ cases:
     +F0 = []
     +G0 = []
     diff --git C/Cargo.toml C/Cargo.toml
-    index 4340ea8ca3..01b8fc2540 100644
+    index 96ff11808e..ee8de9f46c 100644
     --- C/Cargo.toml
     +++ C/Cargo.toml
-    @@ -14,4 +14,2 @@ edition = "2021"
+    @@ -14,4 +14,2 @@ edition = "2024"
     -F0 = [
     -]
     -G0 = [

--- a/tests/ui/fmt/check.yaml
+++ b/tests/ui/fmt/check.yaml
@@ -52,10 +52,10 @@ cases:
     Formatted 3 crates (all fixed).
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index 1044fbc43e..d813df2a4f 100644
+    index 5b6b2a98ad..cf40203c54 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
-    @@ -18,8 +18,2 @@ C = { version = "*", path = "../C"}
+    @@ -16,8 +16,2 @@ C = { version = "*", path = "../C"}
     -F0 = [
     -"B/F0",
     -"C/F0",
@@ -67,10 +67,10 @@ cases:
     +F0 = [ "B/F0", "C/F0" ]
     +G0 = [ "B/G0", "C/G0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index 043e5600eb..ab4a7ef93f 100644
+    index b1f73da9de..9f0724ae5f 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -16,4 +16,2 @@ edition = "2021"
+    @@ -14,4 +14,2 @@ edition = "2021"
     -F0 = [
     -]
     -G0 = [
@@ -78,10 +78,10 @@ cases:
     +F0 = []
     +G0 = []
     diff --git C/Cargo.toml C/Cargo.toml
-    index 4f6a03398d..8720b7b7eb 100644
+    index 4340ea8ca3..01b8fc2540 100644
     --- C/Cargo.toml
     +++ C/Cargo.toml
-    @@ -16,4 +16,2 @@ edition = "2021"
+    @@ -14,4 +14,2 @@ edition = "2021"
     -F0 = [
     -]
     -G0 = [
@@ -98,10 +98,10 @@ cases:
   code: 0
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index 1044fbc43e..d813df2a4f 100644
+    index 5b6b2a98ad..cf40203c54 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
-    @@ -18,8 +18,2 @@ C = { version = "*", path = "../C"}
+    @@ -16,8 +16,2 @@ C = { version = "*", path = "../C"}
     -F0 = [
     -"B/F0",
     -"C/F0",
@@ -113,10 +113,10 @@ cases:
     +F0 = [ "B/F0", "C/F0" ]
     +G0 = [ "B/G0", "C/G0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index 043e5600eb..ab4a7ef93f 100644
+    index b1f73da9de..9f0724ae5f 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -16,4 +16,2 @@ edition = "2021"
+    @@ -14,4 +14,2 @@ edition = "2021"
     -F0 = [
     -]
     -G0 = [
@@ -124,10 +124,10 @@ cases:
     +F0 = []
     +G0 = []
     diff --git C/Cargo.toml C/Cargo.toml
-    index 4f6a03398d..8720b7b7eb 100644
+    index 4340ea8ca3..01b8fc2540 100644
     --- C/Cargo.toml
     +++ C/Cargo.toml
-    @@ -16,4 +16,2 @@ edition = "2021"
+    @@ -14,4 +14,2 @@ edition = "2021"
     -F0 = [
     -]
     -G0 = [

--- a/tests/ui/fmt/dedub.yaml
+++ b/tests/ui/fmt/dedub.yaml
@@ -20,7 +20,7 @@ cases:
     Formatted 2 crates (all fixed).
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index abe9319f17..1368faef82 100644
+    index eba55cd80c..8849621452 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
     @@ -15,4 +15 @@ B = { version = "*", path = "../B"}
@@ -30,10 +30,10 @@ cases:
     -]
     +F0 = [ "B/F0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index e52ef09a77..53767a7726 100644
+    index 195f3af664..4f68eee744 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -14,2 +14 @@ edition = "2021"
+    @@ -14,2 +14 @@ edition = "2024"
     -F0 = [
     -]
     +F0 = []

--- a/tests/ui/fmt/dedub.yaml
+++ b/tests/ui/fmt/dedub.yaml
@@ -20,20 +20,20 @@ cases:
     Formatted 2 crates (all fixed).
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index 78c5769bd7..8a27508a42 100644
+    index abe9319f17..1368faef82 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
-    @@ -17,4 +17 @@ B = { version = "*", path = "../B"}
+    @@ -15,4 +15 @@ B = { version = "*", path = "../B"}
     -F0 = [
     -"B/F0",
     -"B/F0",
     -]
     +F0 = [ "B/F0" ]
     diff --git B/Cargo.toml B/Cargo.toml
-    index 3fa22af3e1..db61ce3b2d 100644
+    index e52ef09a77..53767a7726 100644
     --- B/Cargo.toml
     +++ B/Cargo.toml
-    @@ -16,2 +16 @@ edition = "2021"
+    @@ -14,2 +14 @@ edition = "2021"
     -F0 = [
     -]
     +F0 = []

--- a/tests/ui/lint/propagate-feature/fix_from_no_feat.yaml
+++ b/tests/ui/lint/propagate-feature/fix_from_no_feat.yaml
@@ -16,7 +16,7 @@ cases:
   code: 0
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index d2ffd1442c..9e0240b25f 100644
+    index 7f2ba2ef51..197e942470 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
     @@ -14,0 +15 @@ B = { version = "*", path = "../B"}
@@ -31,7 +31,7 @@ cases:
   code: 0
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index d2ffd1442c..9e0240b25f 100644
+    index 7f2ba2ef51..197e942470 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
     @@ -14,0 +15 @@ B = { version = "*", path = "../B"}

--- a/tests/ui/lint/propagate-feature/fix_from_no_feat.yaml
+++ b/tests/ui/lint/propagate-feature/fix_from_no_feat.yaml
@@ -16,10 +16,10 @@ cases:
   code: 0
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index b7a1745505..cce8f20e73 100644
+    index d2ffd1442c..9e0240b25f 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
-    @@ -16,0 +17 @@ B = { version = "*", path = "../B"}
+    @@ -14,0 +15 @@ B = { version = "*", path = "../B"}
     +F0 = []
 - cmd: lint propagate-feature --feature F0 --workspace --fix
   stdout: |
@@ -31,8 +31,8 @@ cases:
   code: 0
   diff: |
     diff --git A/Cargo.toml A/Cargo.toml
-    index b7a1745505..cce8f20e73 100644
+    index d2ffd1442c..9e0240b25f 100644
     --- A/Cargo.toml
     +++ A/Cargo.toml
-    @@ -16,0 +17 @@ B = { version = "*", path = "../B"}
+    @@ -14,0 +15 @@ B = { version = "*", path = "../B"}
     +F0 = []

--- a/tests/ui/lint/propagate-feature/fix_not_propagated.yaml
+++ b/tests/ui/lint/propagate-feature/fix_not_propagated.yaml
@@ -15,7 +15,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex b2b4a461c2..8256aa1ec4 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --fix
   stdout: |
     crate 'A'
@@ -23,7 +23,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex b2b4a461c2..8256aa1ec4 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --fix
 - cmd: lint propagate-feature -p B --feature F1 --fix
 - cmd: lint propagate-feature --feature F0 --workspace --fix
@@ -33,7 +33,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex b2b4a461c2..8256aa1ec4 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --workspace --fix
   stdout: |
     crate 'A'
@@ -41,6 +41,6 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex b2b4a461c2..8256aa1ec4 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --workspace --fix
 - cmd: lint propagate-feature -p B --feature F1 --workspace --fix

--- a/tests/ui/lint/propagate-feature/fix_not_propagated.yaml
+++ b/tests/ui/lint/propagate-feature/fix_not_propagated.yaml
@@ -15,7 +15,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex f0ab897a16..b3e6c0e7eb 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --fix
   stdout: |
     crate 'A'
@@ -23,7 +23,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex f0ab897a16..b3e6c0e7eb 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --fix
 - cmd: lint propagate-feature -p B --feature F1 --fix
 - cmd: lint propagate-feature --feature F0 --workspace --fix
@@ -33,7 +33,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex f0ab897a16..b3e6c0e7eb 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --workspace --fix
   stdout: |
     crate 'A'
@@ -41,6 +41,6 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex f0ab897a16..b3e6c0e7eb 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --workspace --fix
 - cmd: lint propagate-feature -p B --feature F1 --workspace --fix

--- a/tests/ui/lint/propagate-feature/fix_not_propagated_opt.yaml
+++ b/tests/ui/lint/propagate-feature/fix_not_propagated_opt.yaml
@@ -16,7 +16,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 0311ca0ed0..258ff5172a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d7de4ebe58..0f70f461c3 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --fix
   stdout: |
     crate 'A'
@@ -24,7 +24,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 0311ca0ed0..258ff5172a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d7de4ebe58..0f70f461c3 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --fix
 - cmd: lint propagate-feature -p B --feature F1 --fix
 - cmd: lint propagate-feature --feature F0 --workspace --fix
@@ -34,7 +34,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 0311ca0ed0..258ff5172a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d7de4ebe58..0f70f461c3 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --workspace --fix
   stdout: |
     crate 'A'
@@ -42,6 +42,6 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 0311ca0ed0..258ff5172a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d7de4ebe58..0f70f461c3 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --workspace --fix
 - cmd: lint propagate-feature -p B --feature F1 --workspace --fix

--- a/tests/ui/lint/propagate-feature/fix_not_propagated_opt.yaml
+++ b/tests/ui/lint/propagate-feature/fix_not_propagated_opt.yaml
@@ -16,7 +16,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d7de4ebe58..0f70f461c3 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 3332f79684..3dee770310 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --fix
   stdout: |
     crate 'A'
@@ -24,7 +24,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d7de4ebe58..0f70f461c3 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 3332f79684..3dee770310 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --fix
 - cmd: lint propagate-feature -p B --feature F1 --fix
 - cmd: lint propagate-feature --feature F0 --workspace --fix
@@ -34,7 +34,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d7de4ebe58..0f70f461c3 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 3332f79684..3dee770310 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --workspace --fix
   stdout: |
     crate 'A'
@@ -42,6 +42,6 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d7de4ebe58..0f70f461c3 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 3332f79684..3dee770310 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B?/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --workspace --fix
 - cmd: lint propagate-feature -p B --feature F1 --workspace --fix

--- a/tests/ui/lint/propagate-feature/fix_not_propagated_opt_re.yaml
+++ b/tests/ui/lint/propagate-feature/fix_not_propagated_opt_re.yaml
@@ -17,7 +17,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 78d1bf67c7..ef4a53c4ad 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex e8a14dd805..ded9214270 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --fix
   stdout: |
     crate 'A'
@@ -25,7 +25,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 78d1bf67c7..ef4a53c4ad 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex e8a14dd805..ded9214270 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --fix
 - cmd: lint propagate-feature -p B --feature F1 --fix
 - cmd: lint propagate-feature --feature F0 --workspace --fix
@@ -35,7 +35,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 78d1bf67c7..ef4a53c4ad 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex e8a14dd805..ded9214270 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --workspace --fix
   stdout: |
     crate 'A'
@@ -43,6 +43,6 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 78d1bf67c7..ef4a53c4ad 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex e8a14dd805..ded9214270 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --workspace --fix
 - cmd: lint propagate-feature -p B --feature F1 --workspace --fix

--- a/tests/ui/lint/propagate-feature/fix_not_propagated_opt_re.yaml
+++ b/tests/ui/lint/propagate-feature/fix_not_propagated_opt_re.yaml
@@ -17,7 +17,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex ddbf2ae32f..22e27b583b 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"b?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 78d1bf67c7..ef4a53c4ad 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --fix
   stdout: |
     crate 'A'
@@ -25,7 +25,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex ddbf2ae32f..22e27b583b 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"b?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 78d1bf67c7..ef4a53c4ad 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --fix
 - cmd: lint propagate-feature -p B --feature F1 --fix
 - cmd: lint propagate-feature --feature F0 --workspace --fix
@@ -35,7 +35,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex ddbf2ae32f..22e27b583b 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"b?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 78d1bf67c7..ef4a53c4ad 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --workspace --fix
   stdout: |
     crate 'A'
@@ -43,6 +43,6 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex ddbf2ae32f..22e27b583b 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"b?/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 78d1bf67c7..ef4a53c4ad 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b?/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --workspace --fix
 - cmd: lint propagate-feature -p B --feature F1 --workspace --fix

--- a/tests/ui/lint/propagate-feature/fix_not_propagates_re.yaml
+++ b/tests/ui/lint/propagate-feature/fix_not_propagates_re.yaml
@@ -16,7 +16,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 1e5203c165..a1453d283c 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --fix
   stdout: |
     crate 'A'
@@ -24,7 +24,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 1e5203c165..a1453d283c 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --fix
 - cmd: lint propagate-feature -p B --feature F1 --fix
 - cmd: lint propagate-feature --feature F0 --workspace --fix
@@ -34,7 +34,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 1e5203c165..a1453d283c 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --workspace --fix
   stdout: |
     crate 'A'
@@ -42,6 +42,6 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 1e5203c165..a1453d283c 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --workspace --fix
 - cmd: lint propagate-feature -p B --feature F1 --workspace --fix

--- a/tests/ui/lint/propagate-feature/fix_not_propagates_re.yaml
+++ b/tests/ui/lint/propagate-feature/fix_not_propagates_re.yaml
@@ -16,7 +16,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 4476b86aba..9053bab806 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --fix
   stdout: |
     crate 'A'
@@ -24,7 +24,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 4476b86aba..9053bab806 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --fix
 - cmd: lint propagate-feature -p B --feature F1 --fix
 - cmd: lint propagate-feature --feature F0 --workspace --fix
@@ -34,7 +34,7 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 4476b86aba..9053bab806 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
 - cmd: lint propagate-feature -p A --feature F0 --workspace --fix
   stdout: |
     crate 'A'
@@ -42,6 +42,6 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 4476b86aba..9053bab806 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
 - cmd: lint propagate-feature -p B --feature F0 --workspace --fix
 - cmd: lint propagate-feature -p B --feature F1 --workspace --fix

--- a/tests/ui/lint/propagate-feature/ignore_missing.yaml
+++ b/tests/ui/lint/propagate-feature/ignore_missing.yaml
@@ -21,7 +21,7 @@ cases:
         must propagate to:
           C
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git B/Cargo.toml B/Cargo.toml\nindex fb75edbc04..84bd583913 100644\n--- B/Cargo.toml\n+++ B/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"C/F0\"\n"
+  diff: "diff --git B/Cargo.toml B/Cargo.toml\nindex 27e98ccfef..f5bb28facb 100644\n--- B/Cargo.toml\n+++ B/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"C/F0\"\n"
 - cmd: lint propagate-feature --feature F0 --fix --ignore-missing-propagate=B/F0:C/F0
   stdout: |
     crate 'A'
@@ -29,7 +29,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex b2b4a461c2..8256aa1ec4 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature --feature F0 --fix --ignore-missing-propagate=A/F0:C/F0
   stdout: |
     crate 'A'
@@ -41,4 +41,4 @@ cases:
         must propagate to:
           C
     Found 2 issues and fixed 2 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\ndiff --git B/Cargo.toml B/Cargo.toml\nindex fb75edbc04..84bd583913 100644\n--- B/Cargo.toml\n+++ B/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"C/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex b2b4a461c2..8256aa1ec4 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\ndiff --git B/Cargo.toml B/Cargo.toml\nindex 27e98ccfef..f5bb28facb 100644\n--- B/Cargo.toml\n+++ B/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"C/F0\"\n"

--- a/tests/ui/lint/propagate-feature/ignore_missing.yaml
+++ b/tests/ui/lint/propagate-feature/ignore_missing.yaml
@@ -21,7 +21,7 @@ cases:
         must propagate to:
           C
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git B/Cargo.toml B/Cargo.toml\nindex 446c68117a..2b4001fa1a 100644\n--- B/Cargo.toml\n+++ B/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"C/F0\"\n"
+  diff: "diff --git B/Cargo.toml B/Cargo.toml\nindex fb75edbc04..84bd583913 100644\n--- B/Cargo.toml\n+++ B/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"C/F0\"\n"
 - cmd: lint propagate-feature --feature F0 --fix --ignore-missing-propagate=B/F0:C/F0
   stdout: |
     crate 'A'
@@ -29,7 +29,7 @@ cases:
         must propagate to:
           B
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex f0ab897a16..b3e6c0e7eb 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\n"
 - cmd: lint propagate-feature --feature F0 --fix --ignore-missing-propagate=A/F0:C/F0
   stdout: |
     crate 'A'
@@ -41,4 +41,4 @@ cases:
         must propagate to:
           C
     Found 2 issues and fixed 2 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex f0ab897a16..b3e6c0e7eb 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"B/F0\"\ndiff --git B/Cargo.toml B/Cargo.toml\nindex 446c68117a..2b4001fa1a 100644\n--- B/Cargo.toml\n+++ B/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"C/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex d966d926ca..c63006131a 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"B/F0\"\ndiff --git B/Cargo.toml B/Cargo.toml\nindex fb75edbc04..84bd583913 100644\n--- B/Cargo.toml\n+++ B/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"C/F0\"\n"

--- a/tests/ui/lint/propagate-feature/ignore_missing_re.yaml
+++ b/tests/ui/lint/propagate-feature/ignore_missing_re.yaml
@@ -17,4 +17,4 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 1e5203c165..a1453d283c 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -17,0 +18 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"

--- a/tests/ui/lint/propagate-feature/ignore_missing_re.yaml
+++ b/tests/ui/lint/propagate-feature/ignore_missing_re.yaml
@@ -17,4 +17,4 @@ cases:
         must propagate to:
           b (renamed from B)
     Found 1 issue and fixed 1 (all fixed).
-  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex a185683e4e..e715061b54 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"
+  diff: "diff --git A/Cargo.toml A/Cargo.toml\nindex 4476b86aba..9053bab806 100644\n--- A/Cargo.toml\n+++ A/Cargo.toml\n@@ -15,0 +16 @@ F0 = [\n+\t\"b/F0\"\n"

--- a/tests/ui/root-args/version.yaml
+++ b/tests/ui/root-args/version.yaml
@@ -2,7 +2,7 @@ crates: []
 cases:
 - cmd: --version
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0
 - cmd: -V
   stdout: |
-    zepter 1.5.1
+    zepter 1.78.0


### PR DESCRIPTION
Rust <1.78 has different behaviour of `cargo metadata` naming and required some hacks in the code.  
Code was now cleaned up but will probably not work correctly for <1.78.