### PR TITLE
README binstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ From source code:
 cargo install zepter -f --locked
 ```
 
-From binary (build via GitHub CI):  
+As binary via [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall):  
 
 ```sh
 cargo binstall -y zepter

--- a/README.md
+++ b/README.md
@@ -9,8 +9,16 @@ Analyze, Fix and Format features in your Rust workspace. The goal of this tool i
 
 ## Install
 
+From source code:
+
 ```sh
 cargo install zepter -f --locked
+```
+
+From binary (build via GitHub CI):  
+
+```sh
+cargo binstall -y zepter
 ```
 
 ## Commands


### PR DESCRIPTION
Added installation instructions for Zepter from source and binary.

Close #163, last release 1.85 has proper binaries attached.