### PR TITLE
fix: use cargo_bin macro in tests

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -37,8 +37,7 @@ fn integration() {
 			let _init = case.init(workspace.as_path()).unwrap();
 			colour::white!("{} {}/{} ", file.display(), i + 1, m);
 			git_reset(workspace.as_path()).unwrap();
-			#[allow(deprecated)]
-			let mut cmd = Command::cargo_bin("zepter").unwrap();
+			let mut cmd = Command::new(assert_cmd::cargo_bin!("zepter"));
 			for arg in case.cmd.split_whitespace() {
 				cmd.arg(arg);
 			}


### PR DESCRIPTION
Replaces the deprecated assert_cmd cargo_bin helper with the cargo_bin! macro so the integration test command lookup works with custom Cargo build directories. Closes #177.